### PR TITLE
chore: add extra examples for send message endpoint with media types

### DIFF
--- a/docs/api_reference/messages_api/post_send_messages.md
+++ b/docs/api_reference/messages_api/post_send_messages.md
@@ -47,3 +47,99 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
   }
 }
 ```
+
+## Send Message with Media Attachments
+
+You can use the API to send **media messages** containing **images**, **documents**, **audio** and **video** messages.
+
+Is it also possible to add a _caption_ when sending `image` attachments (see the example request below).
+
+### Send Image Attachment Example
+
+```bash title=request.sh
+```bash title=request.sh
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "url": "https://example.com/my_image.jpeg"
+    }
+  }'
+```
+
+### Send Image Attachment & Caption Example
+
+```bash title=request.sh
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "url": "https://example.com/my_image.jpeg",
+      "text: "This is my caption"
+    }
+  }'
+```
+
+### Send Document Attachment Example
+
+```bash title=request.sh
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_image.pdf"
+    }
+  }'
+```
+
+### Send Audio Attachment Example
+
+:::info
+This is only available for accounts using the official **WhatsApp Business API** integration.
+:::
+
+```bash title=request.sh
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_audio.mp3"
+    }
+  }'
+```
+
+### Send Video Attachment Example
+
+:::info
+This is only available for accounts using the official **WhatsApp Business API** integration.
+:::
+
+```bash title=request.sh
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_video.mp4"
+    }
+  }'
+```


### PR DESCRIPTION
fix #3 

### PR Description

Adds examples of the new media attachment types allowed by the merge of https://github.com/callbellchat/callbell/pull/1400. 