### PR TITLE
enh: add template messages docs

### DIFF
--- a/docs/api_reference/messages_api/post_send_messages.md
+++ b/docs/api_reference/messages_api/post_send_messages.md
@@ -182,7 +182,7 @@ In this context `text` refers to the placeholder of the template message, for ex
 Hello {{1}}, this is a template message example
 ```
 
-After the request above the sent message will be the following:
+The placeholder replacement will be done with the value passed in the payload, so in this case it will be the following:
 
 ```bash title=template_example
 Hello John Doe, this is a template message example

--- a/docs/api_reference/messages_api/post_send_messages.md
+++ b/docs/api_reference/messages_api/post_send_messages.md
@@ -13,6 +13,12 @@ title: POST /messages/send
 | `type`    | MessageType    | Type of message to be sent           |
 | `content` | MessageContent | Content of the message               |
 
+### Optional Parameters
+
+| Parameter       | Type         | Description                                                       |
+| :-------------- | :----------- | :---------------------------------------------------------------- |
+| `template_uuid` | TemplateUUID | Unique identifier of the template message                         |
+| `optin_contact` | Boolean      | Confirmation that the contact has opted-in for receiving messages |
 
 ### Example Request
 
@@ -36,7 +42,6 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
 | :-------- | :--------------------------------------------------------------------- | :----------------------------------------------------------------------- |
 | message   | [MessageSendRequest](/api_reference/object_types/message_send_request) | The message send request. The system will initially enqueue the message. |
 
-
 ### Example Response
 
 ```json title=response.json
@@ -56,7 +61,6 @@ Is it also possible to add a _caption_ when sending `image` attachments (see the
 
 ### Send Image Attachment Example
 
-```bash title=request.sh
 ```bash title=request.sh
 curl -X POST "https://api.callbell.eu/v1/messages/send" \
   -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
@@ -141,5 +145,111 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
     "content": {
       "url": "https://example.com/my_video.mp4"
     }
+  }'
+```
+
+## Send Template Messages
+
+:::info
+This is only available for accounts using the official **WhatsApp Business API** integration.
+:::
+
+You can use the API to send an approved [Template](/api_reference/object_types/template) Message
+In order to send template messages `template_uuid` and `optin_contact` **must** be present in the payload.
+
+Use the [Templates API](/api_reference/template_messages_api/introduction) to the get the `template_uuid`s
+
+```bash title=request.sh
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "text",
+    "content": {
+      "text": "John Doe"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }'
+```
+
+In this context `text` refers to the placeholder of the template message, let's say that you have a template message like this:
+
+```bash title=template_example
+Hello {{1}}, this is a template message example
+```
+
+After the request above the sent message will be the following:
+
+```bash title=template_example
+Hello John Doe, this is a template message example
+```
+
+## Send Template Messages with Media Attachments
+
+:::info
+This is only available for accounts using the official **WhatsApp Business API** integration.
+:::
+
+You can use the API to send an approved [Template](/api_reference/object_types/template) Message
+In order to send template messages `template_uuid` and `optin_contact` must be present in the payload.
+If you have media template messages approved, you can send them by including a valid `url` of the media
+
+### Send Image Attachment
+
+```bash title=request.sh
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_image"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }'
+```
+
+### Send Document Attachment
+
+```bash title=request.sh
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_image"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }'
+```
+
+### Send Video Attachment
+
+```bash title=request.sh
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "video",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_image"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
   }'
 ```

--- a/docs/api_reference/messages_api/post_send_messages.md
+++ b/docs/api_reference/messages_api/post_send_messages.md
@@ -15,10 +15,10 @@ title: POST /messages/send
 
 ### Optional Parameters
 
-| Parameter       | Type         | Description                                                       |
-| :-------------- | :----------- | :---------------------------------------------------------------- |
-| `template_uuid` | TemplateUUID | Unique identifier of the template message                         |
-| `optin_contact` | Boolean      | Confirmation that the contact has opted-in for receiving messages |
+| Parameter       | Type    | Description                                                       |
+| :-------------- | :------ | :---------------------------------------------------------------- |
+| `template_uuid` | string  | Unique identifier of the template message                         |
+| `optin_contact` | Boolean | Confirmation that the contact has opted-in for receiving messages |
 
 ### Example Request
 
@@ -150,14 +150,15 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
 
 ## Send Template Messages
 
+You can use the API to send an approved [Template](/api_reference/object_types/template) Message.
+
 :::info
 This is only available for accounts using the official **WhatsApp Business API** integration.
 :::
 
-You can use the API to send an approved [Template](/api_reference/object_types/template) Message
+:::caution
 In order to send template messages `template_uuid` and `optin_contact` **must** be present in the payload.
-
-Use the [Templates API](/api_reference/template_messages_api/introduction) to the get the `template_uuid`s
+:::
 
 ```bash title=request.sh
 curl -X POST "https://api.callbell.eu/v1/messages/send" \
@@ -175,7 +176,7 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
   }'
 ```
 
-In this context `text` refers to the placeholder of the template message, let's say that you have a template message like this:
+In this context `text` refers to the placeholder of the template message, for example let's say you have a template message like this:
 
 ```bash title=template_example
 Hello {{1}}, this is a template message example
@@ -189,12 +190,16 @@ Hello John Doe, this is a template message example
 
 ## Send Template Messages with Media Attachments
 
+You can use the API to send an approved [Template](/api_reference/object_types/template) Message
+
 :::info
 This is only available for accounts using the official **WhatsApp Business API** integration.
 :::
 
-You can use the API to send an approved [Template](/api_reference/object_types/template) Message
+:::caution
 In order to send template messages `template_uuid` and `optin_contact` must be present in the payload.
+:::
+
 If you have media template messages approved, you can send them by including a valid `url` of the media
 
 ### Send Image Attachment
@@ -209,7 +214,7 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
     "type": "image",
     "content": {
       "text": "John Doe",
-      "url": "https://example.com/valid_image"
+      "url": "https://example.com/valid_image.jpeg"
     },
     "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
     "optin_contact": true
@@ -228,7 +233,7 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
     "type": "document",
     "content": {
       "text": "John Doe",
-      "url": "https://example.com/valid_image"
+      "url": "https://example.com/valid_document.pdf"
     },
     "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
     "optin_contact": true
@@ -247,9 +252,13 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
     "type": "video",
     "content": {
       "text": "John Doe",
-      "url": "https://example.com/valid_image"
+      "url": "https://example.com/valid_video.mp4"
     },
     "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
     "optin_contact": true
   }'
 ```
+
+:::info
+Use the [Templates API](/api_reference/template_messages_api/introduction) to the get the `template_uuid`s your templates.
+:::

--- a/docs/api_reference/template_messages_api/introduction.md
+++ b/docs/api_reference/template_messages_api/introduction.md
@@ -8,6 +8,6 @@ Templates API allows to recover details regarding the template messages used on 
 
 :::caution
 
-At the moment we **only** support template messages for Whatsapp API (Gupshup) integrations, therefore the only template messages available are the ones approved for WhatsApp.
+At the moment we **only** support template messages for WhatsApp Business API (Gupshup) integrations, which needs to be pre-approved by WhatsApp itself. For further information regarding template approvals please reach out to us.
 
 :::


### PR DESCRIPTION
### Desctiprion 
In this PR we cover the template messages send option in the `Messages API`