### PR TITLE
Enh/add-multi-code-blocks

### DIFF
--- a/docs/api_reference/auth_api/me.md
+++ b/docs/api_reference/auth_api/me.md
@@ -1,7 +1,9 @@
 ---
-title: POST /auth/me
+title: Get /auth/me
 sidebar_position: 1
 ---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
 
 # GET /auth/me
 
@@ -9,11 +11,7 @@ Return a `200` status code if the `api_token` is valid.
 
 ### Example Request
 
-```bash title=request.sh
-curl -X GET "https://api.callbell.eu/v1/auth/me" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='auth_api' request="get_me"/>
 
 ### Response
 

--- a/docs/api_reference/contacts_api/delete_contact.md
+++ b/docs/api_reference/contacts_api/delete_contact.md
@@ -3,6 +3,8 @@ title: DELETE /contacts/:uuid
 sidebar_position: 6
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # DELETE /contacts/:uuid
 
 Deletes a specific contact given a `uuid`.
@@ -13,28 +15,21 @@ This operation is **unreversible**. Always double-check the correctness of your 
 
 :::
 
-
 ### Required Parameters
 
 | Parameter | Type   | Description             |
 | :-------- | :----- | :---------------------- |
 | `uuid`    | string | The uuid of the contact |
 
-
 ### Example Request
 
-```bash title=request.sh
-curl -X DELETE "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='contacts_api' request='delete_contact'/>
 
 ### Response
 
 | Parameter | Type   | Description              |
 | :-------- | :----- | :----------------------- |
 | `status`  | string | Status of the operation. |
-
 
 ### Example Response
 

--- a/docs/api_reference/contacts_api/get_contact.md
+++ b/docs/api_reference/contacts_api/get_contact.md
@@ -3,6 +3,8 @@ title: GET /contacts/:uuid
 sidebar_position: 3
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # GET /contact/:uuid
 
 Get a specific contact given a `uuid`.
@@ -15,11 +17,7 @@ Get a specific contact given a `uuid`.
 
 ### Example Request
 
-```bash title=request.sh
-curl -X GET "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='contacts_api' request="get_contact"/>
 
 ### Response
 

--- a/docs/api_reference/contacts_api/get_contact_by_phone.md
+++ b/docs/api_reference/contacts_api/get_contact_by_phone.md
@@ -3,23 +3,21 @@ title: GET /contacts/phone/:number
 sidebar_position: 4
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # GET /contacts/phone/:number
 
 Get a specific contact given a `phone_number`.
 
 ### Required Parameters
 
-| Parameter         | Type   | Description                     |
-| :-----------------| :----- | :------------------------------ |
-| `phone_number`    | string | The phone number of the contact |
+| Parameter      | Type   | Description                     |
+| :------------- | :----- | :------------------------------ |
+| `phone_number` | string | The phone number of the contact |
 
 ### Example Request
 
-```bash title=request.sh
-curl -X GET "https://api.callbell.eu/v1/contacts/phone/5790372023" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='contacts_api' request="get_contact_by_phone"/>
 
 ### Response
 
@@ -32,19 +30,19 @@ curl -X GET "https://api.callbell.eu/v1/contacts/phone/5790372023" \
 ```json title=response.json
 {
   "contact": {
-      "uuid": "414a6d692bd645ed803f2e7ce360d4c8",
-      "name": "John Doe",
-      "phoneNumber": "+123 456 789",
-      "avatarUrl": null,
-      "createdAt": "2020-11-13T21:08:53Z",
-      "source": "whatsapp",
-      "href": "https://dash.callbell.eu/contacts/414a6d692bd645ed803f2e7ce360d4c8",
-      "tags": ["sales", "lead"],
-      "customFields": {
-        "Address": "Oxford Street 123",
-        "Billing Address": "Oxford Street 123",
-        "VAT": "ABC123DCE456"
-      }
+    "uuid": "414a6d692bd645ed803f2e7ce360d4c8",
+    "name": "John Doe",
+    "phoneNumber": "+123 456 789",
+    "avatarUrl": null,
+    "createdAt": "2020-11-13T21:08:53Z",
+    "source": "whatsapp",
+    "href": "https://dash.callbell.eu/contacts/414a6d692bd645ed803f2e7ce360d4c8",
+    "tags": ["sales", "lead"],
+    "customFields": {
+      "Address": "Oxford Street 123",
+      "Billing Address": "Oxford Street 123",
+      "VAT": "ABC123DCE456"
     }
+  }
 }
 ```

--- a/docs/api_reference/contacts_api/get_contacts.md
+++ b/docs/api_reference/contacts_api/get_contacts.md
@@ -3,6 +3,8 @@ title: GET /contacts
 sidebar_position: 2
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # GET /contacts
 
 List all contacts belonging to the account. A filter can be specified in order to get more specific results.
@@ -17,11 +19,7 @@ List all contacts belonging to the account. A filter can be specified in order t
 
 ### Example Request
 
-```bash title=request.sh
-curl -X GET "https://api.callbell.eu/v1/contacts?page=1&source=whatsapp&tags=sales,lead" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='contacts_api' request="get_contacts"/>
 
 ### Response
 

--- a/docs/api_reference/contacts_api/patch_contacts.md
+++ b/docs/api_reference/contacts_api/patch_contacts.md
@@ -3,6 +3,8 @@ title: PATCH /contacts/:uuid
 sidebar_position: 5
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # PATCH /contacts/:uuid
 
 Updates an existing contact.
@@ -15,16 +17,11 @@ Updates an existing contact.
 
 ### Optional Parameters
 
-All parameters reported by Contact _except_ `uuid`.
+All parameters reported by [Contact](/api_reference/object_types/contact) _except_ `uuid`.
 
 ### Example Request
 
-```bash title=request.sh
-curl -X PATCH "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-  -d '{"name": "UPDATE Doe"}'
-```
+<RequestTabs endpoint='contacts_api' request="patch_contacts"/>
 
 ### Response
 
@@ -45,7 +42,8 @@ curl -X PATCH "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d
       "createdAt": "2020-11-13T21:08:53Z",
       "source": "whatsapp",
       "href": "https://dash.callbell.eu/contacts/414a6d692bd645ed803f2e7ce360d4c8",
-      "tags": []
+      "tags": [],
+      "customFields": {}
     }
   ]
 }

--- a/docs/api_reference/contacts_api/post_contacts.md
+++ b/docs/api_reference/contacts_api/post_contacts.md
@@ -3,6 +3,8 @@ title: POST /contacts
 sidebar_position: 4
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # POST /contacts
 
 Creates a new contact.
@@ -17,23 +19,13 @@ Creates a new contact.
 
 ### Example Request
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-  -d '{
-    	"source": "whatsapp",
-	    "identifier": "123456789",
-	    "name": "John Doe"
-  }'
-```
+<RequestTabs endpoint='contacts_api' request="post_contacts"/>
 
 ### Response
 
 | Parameter | Type                                           | Description                    |
 | :-------- | :--------------------------------------------- | :----------------------------- |
 | `contact` | [Contact](/api_reference/object_types/contact) | The contact which was created. |
-
 
 ### Example Response
 
@@ -48,7 +40,8 @@ curl -X POST "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4
       "createdAt": "2020-11-13T21:08:53Z",
       "source": "whatsapp",
       "href": "https://dash.callbell.eu/contacts/414a6d692bd645ed803f2e7ce360d4c8",
-      "tags": []
+      "tags": [],
+      "customFields": {}
     }
   ]
 }

--- a/docs/api_reference/messages_api/get_message_status.md
+++ b/docs/api_reference/messages_api/get_message_status.md
@@ -3,6 +3,8 @@ title: GET /messages/status/:uuid
 sidebar_position: 3
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # GET /messages/status/:uuid
 
 ### Required Parameters
@@ -11,17 +13,12 @@ sidebar_position: 3
 | :-------- | :----- | :---------------------------------------------------- |
 | `uuid`    | String | Identifier of the message which was sent through API. |
 
-
-
 ### Example Request
 
-```bash title=request.sh
-curl -X GET "https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='messages_api' request="get_message_status"/>
 
 ### Response
+
 | Parameter | Type                                                                   | Description                                  |
 | :-------- | :--------------------------------------------------------------------- | :------------------------------------------- |
 | `message` | [MessageSendRequest](/api_reference/object_types/message_send_request) | The message details comprehensive of status. |

--- a/docs/api_reference/messages_api/post_send_messages.md
+++ b/docs/api_reference/messages_api/post_send_messages.md
@@ -2,6 +2,8 @@
 title: POST /messages/send
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # POST /messages/send
 
 :::caution
@@ -26,19 +28,7 @@ After 24h without a reply from the customer, it is not possible to send regular 
 
 ### Example Request
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "text",
-    "content": {
-      "text": "Hello!"
-    }
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages"/>
 
 ### Response
 
@@ -65,52 +55,15 @@ Is it also possible to add a _caption_ when sending `image` attachments (see the
 
 ### Send Image Attachment Example
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "image",
-    "content": {
-      "url": "https://example.com/my_image.jpeg"
-    }
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages_image"/>
 
 ### Send Image Attachment & Caption Example
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "image",
-    "content": {
-      "url": "https://example.com/my_image.jpeg",
-      "text: "This is my caption"
-    }
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages_image_caption"/>
 
 ### Send Document Attachment Example
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "document",
-    "content": {
-      "url": "https://example.com/my_image.pdf"
-    }
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages_document"/>
 
 ### Send Audio Attachment Example
 
@@ -118,19 +71,7 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
 This is only available for accounts using the official **WhatsApp Business API** integration.
 :::
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "document",
-    "content": {
-      "url": "https://example.com/my_audio.mp3"
-    }
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages_audio"/>
 
 ### Send Video Attachment Example
 
@@ -138,19 +79,7 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
 This is only available for accounts using the official **WhatsApp Business API** integration.
 :::
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "document",
-    "content": {
-      "url": "https://example.com/my_video.mp4"
-    }
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages_video"/>
 
 ## Send Template Messages
 
@@ -164,21 +93,7 @@ This is only available for accounts using the official **WhatsApp Business API**
 In order to send template messages `template_uuid` and `optin_contact` **must** be present in the payload.
 :::
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "text",
-    "content": {
-      "text": "John Doe"
-    },
-    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
-    "optin_contact": true
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages_template"/>
 
 In this context `text` refers to the placeholder of the template message, for example let's say you have a template message like this:
 
@@ -208,60 +123,15 @@ If you have media template messages approved, you can send them by including a v
 
 ### Send Image Attachment
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "image",
-    "content": {
-      "text": "John Doe",
-      "url": "https://example.com/valid_image.jpeg"
-    },
-    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
-    "optin_contact": true
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages_template_image"/>
 
 ### Send Document Attachment
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "document",
-    "content": {
-      "text": "John Doe",
-      "url": "https://example.com/valid_document.pdf"
-    },
-    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
-    "optin_contact": true
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages_template_document"/>
 
 ### Send Video Attachment
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/messages/send" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "to": "+31612345678",
-    "from": "whatsapp",
-    "type": "video",
-    "content": {
-      "text": "John Doe",
-      "url": "https://example.com/valid_video.mp4"
-    },
-    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
-    "optin_contact": true
-  }'
-```
+<RequestTabs endpoint='messages_api' request="post_messages_template_video"/>
 
 :::info
 Use the [Templates API](/api_reference/template_messages_api/introduction) to the get the `template_uuid`s your templates.

--- a/docs/api_reference/template_messages_api/get_template.md
+++ b/docs/api_reference/template_messages_api/get_template.md
@@ -3,6 +3,8 @@ title: GET /templates/:uuid
 sidebar_position: 3
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # GET /templates/:uuid
 
 Get a specific template given a `uuid`.
@@ -15,11 +17,7 @@ Get a specific template given a `uuid`.
 
 ### Example Request
 
-```bash title=request.sh
-curl -X GET "https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='templates_api' request="get_template"/>
 
 ### Response
 

--- a/docs/api_reference/template_messages_api/get_templates.md
+++ b/docs/api_reference/template_messages_api/get_templates.md
@@ -3,17 +3,15 @@ title: GET /templates
 sidebar_position: 2
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # GET /templates
 
 List all templates belonging to the account.
 
 ### Example Request
 
-```bash title=request.sh
-curl -X GET "https://api.callbell.eu/v1/templates" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='templates_api' request="get_templates"/>
 
 ### Response
 

--- a/docs/api_reference/template_messages_api/patch_templates.md
+++ b/docs/api_reference/template_messages_api/patch_templates.md
@@ -3,6 +3,8 @@ title: PATCH /templates/:uuid
 sidebar_position: 4
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # PATCH /templates/:uuid
 
 Updates an existing template.
@@ -21,12 +23,7 @@ Updates an existing template.
 
 ### Example Request
 
-```bash title=request.sh
-curl -X PATCH "https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-  -d '{"title": New title"}'
-```
+<RequestTabs endpoint='templates_api' request="patch_template"/>
 
 ### Response
 

--- a/docs/api_reference/webhooks_api/events.md
+++ b/docs/api_reference/webhooks_api/events.md
@@ -3,6 +3,8 @@ title: GET /webhooks/events
 sidebar_position: 4
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # GET /events
 
 List all events belonging to the webhook. A filter can be specified in order to get more specific results.
@@ -18,11 +20,7 @@ List all events belonging to the webhook. A filter can be specified in order to 
 
 ### Example Request
 
-```bash title=request.sh
-curl -X GET "https://api.callbell.eu/v1/webhooks/events" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='webhooks_api' request="get_webhooks_events"/>
 
 ### Response
 

--- a/docs/api_reference/webhooks_api/subscribe.md
+++ b/docs/api_reference/webhooks_api/subscribe.md
@@ -3,6 +3,8 @@ title: POST /webhooks/subscribe
 sidebar_position: 2
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # POST /subscriptions
 
 Creates a new webhook or updates an existing one.
@@ -22,15 +24,7 @@ Each account can **only** register 1 webhook.
 
 ### Example Request
 
-```bash title=request.sh
-curl -X POST "https://api.callbell.eu/v1/webhooks/subscribe" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-  -d '{
-    	"url": "https://my-app.com/my-webhook-endpoint",
-        "subscriptions": ["message_created", "contact_created"]
-  }'
-```
+<RequestTabs endpoint='webhooks_api' request="post_webhooks_subscribe"/>
 
 ### Response
 

--- a/docs/api_reference/webhooks_api/unsubscribe.md
+++ b/docs/api_reference/webhooks_api/unsubscribe.md
@@ -3,17 +3,15 @@ title: DELETE /webhooks/unsubscribe
 sidebar_position: 3
 ---
 
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
 # DELETE /webhooks/unsubscribe
 
 Deletes the webhook of the current account.
 
 ### Example Request
 
-```bash title=request.sh
-curl -X DELETE "https://api.callbell.eu/v1/webhooks/unsubscribe" \
-  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
-  -H "Content-Type: application/json"
-```
+<RequestTabs endpoint='webhooks_api' request="delete_webhooks_unsubscribe"/>
 
 ### Response
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -85,6 +85,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ["ruby", "php"],
       },
     }),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@docusaurus/preset-classic": "2.1.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
+        "curlconverter": "^4.5.0",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -1962,6 +1963,16 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@curlconverter/tree-sitter-bash": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@curlconverter/tree-sitter-bash/-/tree-sitter-bash-0.0.2.tgz",
+      "integrity": "sha512-ulX5QKkdo/3iR5Dk4pUwWP29JFl92cG2q7Muw0T9mWZer7JbkddKI5tmFaT7GGvFlYm4DF9aIPyjSa1nj5aA0w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.15.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
     "node_modules/@docsearch/css": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
@@ -3723,6 +3734,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -3926,6 +3978,25 @@
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
       "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -3945,6 +4016,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -4073,6 +4154,29 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -4322,6 +4426,11 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -4427,6 +4536,14 @@
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/collapse-white-space": {
@@ -4576,6 +4693,11 @@
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
       "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.2",
@@ -5100,6 +5222,33 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
+    "node_modules/curlconverter": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/curlconverter/-/curlconverter-4.5.0.tgz",
+      "integrity": "sha512-usBziKkb1nyAUQRbTabuIpn4dBXsw9Qh01sKIMXkUOapKVEIr/v0QuFUPyjJHcYqrgqaGaDjmM6vCibnpAAQxA==",
+      "dependencies": {
+        "@curlconverter/tree-sitter-bash": "^0.0.2",
+        "jsesc": "^3.0.2",
+        "lossless-json": "^2.0.2",
+        "tree-sitter": "^0.20.1",
+        "web-tree-sitter": "^0.20.7",
+        "yamljs": "^0.3.0"
+      },
+      "bin": {
+        "curlconverter": "dist/src/cli.js"
+      }
+    },
+    "node_modules/curlconverter/node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5203,6 +5352,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5230,6 +5384,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -5658,6 +5820,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -6132,6 +6302,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -6173,6 +6348,64 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "node_modules/gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6209,6 +6442,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/github-slugger": {
       "version": "1.4.0",
@@ -6453,6 +6691,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "node_modules/has-yarn": {
       "version": "2.1.0",
@@ -6830,6 +7073,25 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -7507,6 +7769,11 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lossless-json": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-2.0.6.tgz",
+      "integrity": "sha512-K7ELexRvOtVHfy+y5Tlv7ZYvbEIZhfSgCtJ+h2mHVeNlxWlv0TfxpqW7Ob/wuCzxXgapsauj+CLbiaefxw3cZA=="
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -7831,6 +8098,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "node_modules/mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -7856,6 +8128,11 @@
         "multicast-dns": "cli.js"
       }
     },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -7866,6 +8143,11 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -7887,6 +8169,17 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
+      "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-emoji": {
@@ -7967,6 +8260,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
     "node_modules/nprogress": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
@@ -7981,6 +8285,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-assign": {
@@ -8972,6 +9284,31 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/prepend-http": {
@@ -10392,6 +10729,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -10475,6 +10817,74 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-get/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/simple-get/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/sirv": {
       "version": "1.0.19",
@@ -10906,6 +11316,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/terser": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
@@ -11046,6 +11482,101 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/tree-sitter": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.1.tgz",
+      "integrity": "sha512-Cmb8V0ocamHbgWMVhZIa+78k/7r8VCQ6+ePG8eYEAO7AccwWi06Ct4ATNiI94KwhIkRl0+OwZ42/5nk3GnEMpQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.14.0",
+        "prebuild-install": "^6.0.1"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/node-abi": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+      "dependencies": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/prebuild-install": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
+      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.21.0",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -11073,6 +11604,17 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -11122,6 +11664,19 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/ua-parser-js": {
@@ -11731,6 +12286,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-tree-sitter": {
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.7.tgz",
+      "integrity": "sha512-flC9JJmTII9uAeeYpWF8hxDJ7bfY+leldQryetll8Nv4WgI+MXc6h7TiyAZASWl9uC9TvmfdgOjZn1DAQecb3A=="
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -12150,6 +12710,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wide-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/wide-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/widest-line": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
@@ -12295,6 +12881,27 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      },
+      "bin": {
+        "json2yaml": "bin/json2yaml",
+        "yaml2json": "bin/yaml2json"
+      }
+    },
+    "node_modules/yamljs/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/yocto-queue": {
@@ -13676,6 +14283,15 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "optional": true
     },
+    "@curlconverter/tree-sitter-bash": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@curlconverter/tree-sitter-bash/-/tree-sitter-bash-0.0.2.tgz",
+      "integrity": "sha512-ulX5QKkdo/3iR5Dk4pUwWP29JFl92cG2q7Muw0T9mWZer7JbkddKI5tmFaT7GGvFlYm4DF9aIPyjSa1nj5aA0w==",
+      "requires": {
+        "nan": "^2.15.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
     "@docsearch/css": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
@@ -14268,7 +14884,8 @@
     "@mdx-js/react": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
-      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg=="
+      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -14339,42 +14956,50 @@
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.3.1.tgz",
-      "integrity": "sha512-jDBKArXYO1u0B1dmd2Nf8Oy6aTF5vLDfLoO9Oon/GLkqZ/NiggYWZA+a2HpUMH4ITwNqS3z43k8LWApB8S583w=="
+      "integrity": "sha512-jDBKArXYO1u0B1dmd2Nf8Oy6aTF5vLDfLoO9Oon/GLkqZ/NiggYWZA+a2HpUMH4ITwNqS3z43k8LWApB8S583w==",
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.3.1.tgz",
-      "integrity": "sha512-dQzyJ4prwjcFd929T43Z8vSYiTlTu8eafV40Z2gO7zy/SV5GT+ogxRJRBIKWomPBOiaVXFg3jY4S5hyEN3IBjQ=="
+      "integrity": "sha512-dQzyJ4prwjcFd929T43Z8vSYiTlTu8eafV40Z2gO7zy/SV5GT+ogxRJRBIKWomPBOiaVXFg3jY4S5hyEN3IBjQ==",
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.3.1.tgz",
-      "integrity": "sha512-HBOUc1XwSU67fU26V5Sfb8MQsT0HvUyxru7d0oBJ4rA2s4HW3PhyAPC7fV/mdsSGpAvOdd8Wpvkjsr0fWPUO7A=="
+      "integrity": "sha512-HBOUc1XwSU67fU26V5Sfb8MQsT0HvUyxru7d0oBJ4rA2s4HW3PhyAPC7fV/mdsSGpAvOdd8Wpvkjsr0fWPUO7A==",
+      "requires": {}
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.3.1.tgz",
-      "integrity": "sha512-C12e6aN4BXAolRrI601gPn5MDFCRHO7C4TM8Kks+rDtl8eEq+NN1sak0eAzJu363x3TmHXdZn7+Efd2nr9I5dA=="
+      "integrity": "sha512-C12e6aN4BXAolRrI601gPn5MDFCRHO7C4TM8Kks+rDtl8eEq+NN1sak0eAzJu363x3TmHXdZn7+Efd2nr9I5dA==",
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.3.1.tgz",
-      "integrity": "sha512-6NU55Mmh3M5u2CfCCt6TX29/pPneutrkJnnDCHbKZnjukZmmgUAZLtZ2g6ZoSPdarowaQmAiBRgAHqHmG0vuqA=="
+      "integrity": "sha512-6NU55Mmh3M5u2CfCCt6TX29/pPneutrkJnnDCHbKZnjukZmmgUAZLtZ2g6ZoSPdarowaQmAiBRgAHqHmG0vuqA==",
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.3.1.tgz",
-      "integrity": "sha512-HV1NGHYTTe1vCNKlBgq/gKuCSfaRlKcHIADn7P8w8U3Zvujdw1rmusutghJ1pZJV7pDt3Gt8ws+SVrqHnBO/Qw=="
+      "integrity": "sha512-HV1NGHYTTe1vCNKlBgq/gKuCSfaRlKcHIADn7P8w8U3Zvujdw1rmusutghJ1pZJV7pDt3Gt8ws+SVrqHnBO/Qw==",
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.3.1.tgz",
-      "integrity": "sha512-2wZhSHvTolFNeKDAN/ZmIeSz2O9JSw72XD+o2bNp2QAaWqa8KGpn5Yk5WHso6xqfSAiRzAE+GXlsrBO4UP9LLw=="
+      "integrity": "sha512-2wZhSHvTolFNeKDAN/ZmIeSz2O9JSw72XD+o2bNp2QAaWqa8KGpn5Yk5WHso6xqfSAiRzAE+GXlsrBO4UP9LLw==",
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.3.1.tgz",
-      "integrity": "sha512-cZ8Tr6ZAWNUFfDeCKn/pGi976iWSkS8ijmEYKosP+6ktdZ7lW9HVLHojyusPw3w0j8PI4VBeWAXAmi/2G7owxw=="
+      "integrity": "sha512-cZ8Tr6ZAWNUFfDeCKn/pGi976iWSkS8ijmEYKosP+6ktdZ7lW9HVLHojyusPw3w0j8PI4VBeWAXAmi/2G7owxw==",
+      "requires": {}
     },
     "@svgr/babel-preset": {
       "version": "6.3.1",
@@ -14879,7 +15504,8 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -14940,7 +15566,8 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "algoliasearch": {
       "version": "4.14.2",
@@ -15021,6 +15648,49 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "arg": {
@@ -15173,6 +15843,11 @@
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
       "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -15187,6 +15862,16 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "body-parser": {
       "version": "1.20.0",
@@ -15284,6 +15969,15 @@
         "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.9"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -15450,6 +16144,11 @@
         "readdirp": "~3.6.0"
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -15526,6 +16225,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -15646,6 +16350,11 @@
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
       "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -15816,7 +16525,8 @@
     "css-declaration-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
-      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w=="
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+      "requires": {}
     },
     "css-loader": {
       "version": "6.7.1",
@@ -15976,7 +16686,8 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -15990,6 +16701,26 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
+    "curlconverter": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/curlconverter/-/curlconverter-4.5.0.tgz",
+      "integrity": "sha512-usBziKkb1nyAUQRbTabuIpn4dBXsw9Qh01sKIMXkUOapKVEIr/v0QuFUPyjJHcYqrgqaGaDjmM6vCibnpAAQxA==",
+      "requires": {
+        "@curlconverter/tree-sitter-bash": "^0.0.2",
+        "jsesc": "^3.0.2",
+        "lossless-json": "^2.0.2",
+        "tree-sitter": "^0.20.1",
+        "web-tree-sitter": "^0.20.7",
+        "yamljs": "^0.3.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+          "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="
+        }
+      }
     },
     "debug": {
       "version": "4.3.4",
@@ -16059,6 +16790,11 @@
         "slash": "^3.0.0"
       }
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -16076,6 +16812,11 @@
       "requires": {
         "repeat-string": "^1.5.4"
       }
+    },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
     },
     "detect-node": {
       "version": "2.1.0",
@@ -16391,6 +17132,11 @@
           "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
         }
       }
+    },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "express": {
       "version": "4.18.1",
@@ -16738,6 +17484,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -16769,6 +17520,54 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -16796,6 +17595,11 @@
       "requires": {
         "pump": "^3.0.0"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "github-slugger": {
       "version": "1.4.0",
@@ -16980,6 +17784,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -17263,7 +18072,13 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "requires": {}
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.0",
@@ -17731,6 +18546,11 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lossless-json": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-2.0.6.tgz",
+      "integrity": "sha512-K7ELexRvOtVHfy+y5Tlv7ZYvbEIZhfSgCtJ+h2mHVeNlxWlv0TfxpqW7Ob/wuCzxXgapsauj+CLbiaefxw3cZA=="
+    },
     "lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -17960,6 +18780,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -17979,10 +18804,20 @@
         "thunky": "^1.0.2"
       }
     },
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+    },
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+    },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "negotiator": {
       "version": "0.6.3",
@@ -18001,6 +18836,14 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node-abi": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
+      "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
+      "requires": {
+        "semver": "^7.3.5"
       }
     },
     "node-emoji": {
@@ -18052,6 +18895,17 @@
         "path-key": "^3.0.0"
       }
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
     "nprogress": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
@@ -18064,6 +18918,11 @@
       "requires": {
         "boolbase": "^1.0.0"
       }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -18416,22 +19275,26 @@
     "postcss-discard-comments": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+      "requires": {}
     },
     "postcss-discard-unused": {
       "version": "5.1.0",
@@ -18519,7 +19382,8 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -18550,7 +19414,8 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -18694,7 +19559,27 @@
     "postcss-zindex": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-5.1.0.tgz",
-      "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A=="
+      "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A==",
+      "requires": {}
+    },
+    "prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      }
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -18718,7 +19603,8 @@
     "prism-react-renderer": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg=="
+      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
+      "requires": {}
     },
     "prismjs": {
       "version": "1.29.0",
@@ -19787,6 +20673,11 @@
         "send": "0.18.0"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -19852,6 +20743,36 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+        }
+      }
     },
     "sirv": {
       "version": "1.0.19",
@@ -20159,6 +21080,29 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "terser": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
@@ -20254,6 +21198,78 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "tree-sitter": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.1.tgz",
+      "integrity": "sha512-Cmb8V0ocamHbgWMVhZIa+78k/7r8VCQ6+ePG8eYEAO7AccwWi06Ct4ATNiI94KwhIkRl0+OwZ42/5nk3GnEMpQ==",
+      "requires": {
+        "nan": "^2.14.0",
+        "prebuild-install": "^6.0.1"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+        },
+        "node-abi": {
+          "version": "2.30.1",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+          "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+          "requires": {
+            "semver": "^5.4.1"
+          }
+        },
+        "prebuild-install": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
+          "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.21.0",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "simple-get": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+          "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+          "requires": {
+            "decompress-response": "^4.2.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
+        }
+      }
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -20273,6 +21289,14 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "type-fest": {
       "version": "2.19.0",
@@ -20310,6 +21334,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true
     },
     "ua-parser-js": {
       "version": "0.7.31",
@@ -20594,12 +21624,14 @@
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.1",
@@ -20702,6 +21734,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
+    },
+    "web-tree-sitter": {
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.7.tgz",
+      "integrity": "sha512-flC9JJmTII9uAeeYpWF8hxDJ7bfY+leldQryetll8Nv4WgI+MXc6h7TiyAZASWl9uC9TvmfdgOjZn1DAQecb3A=="
     },
     "webidl-conversions": {
       "version": "3.0.1",
@@ -20928,7 +21965,8 @@
         "ws": {
           "version": "8.9.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-          "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg=="
+          "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+          "requires": {}
         }
       }
     },
@@ -20987,6 +22025,31 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
       }
     },
     "widest-line": {
@@ -21051,7 +22114,8 @@
     "ws": {
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",
@@ -21080,6 +22144,25 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+    },
+    "yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        }
+      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,15 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "code_snippets": "node src/scripts/generate_code_snippets.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "2.1.0",
     "@docusaurus/preset-classic": "2.1.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "curlconverter": "^4.5.0",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "code_snippets": "node src/scripts/generate_code_snippets.mjs"
+    "translate_snippets": "node src/scripts/generate_code_snippets.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "2.1.0",

--- a/src/components/Requests/RequestTabs.jsx
+++ b/src/components/Requests/RequestTabs.jsx
@@ -36,7 +36,6 @@ export default function RequestTabs(props) {
       value: "Python",
     },
   ];
-  console.log(snippets);
 
   return (
     <>

--- a/src/components/Requests/RequestTabs.jsx
+++ b/src/components/Requests/RequestTabs.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+
+export default function RequestTabs(props) {
+  const snippets = [
+    {
+      key: "bash",
+      component: require(`../../snippets/curl/${props.endpoint}/_${props.request}.mdx`),
+      value: "cURL",
+    },
+    {
+      key: "node",
+      component: require(`../../snippets/node/${props.endpoint}/_${props.request}.mdx`),
+      value: "Node",
+    },
+    {
+      key: "ruby",
+      component: require(`../../snippets/ruby/${props.endpoint}/_${props.request}.mdx`),
+      value: "Ruby",
+    },
+    {
+      key: "go",
+      component: require(`../../snippets/go/${props.endpoint}/_${props.request}.mdx`),
+      value: "Go",
+    },
+    {
+      key: "php",
+      component: require(`../../snippets/php/${props.endpoint}/_${props.request}.mdx`),
+      value: "PHP",
+    },
+    {
+      key: "python",
+      component: require(`../../snippets/python/${props.endpoint}/_${props.request}.mdx`),
+      value: "Python",
+    },
+  ];
+  console.log(snippets);
+
+  return (
+    <>
+      <Tabs groupId="programming-language">
+        {snippets.map((snippet, id) => {
+          const Component = snippet.component;
+
+          return (
+            <TabItem
+              key={id}
+              value={snippet.value}
+              label={snippet.value}
+              default
+            >
+              <CodeBlock
+                language={snippet.key}
+                title="request.sh"
+                showLineNumbers
+              >
+                <Component.default />
+              </CodeBlock>
+            </TabItem>
+          );
+        })}
+      </Tabs>
+    </>
+  );
+}

--- a/src/components/Requests/RequestTabs.jsx
+++ b/src/components/Requests/RequestTabs.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import CodeBlock from "@theme/CodeBlock";
 
 export default function RequestTabs(props) {
   const snippets = [
@@ -50,13 +49,7 @@ export default function RequestTabs(props) {
               label={snippet.value}
               default
             >
-              <CodeBlock
-                language={snippet.key}
-                title="request.sh"
-                showLineNumbers
-              >
-                <Component.default />
-              </CodeBlock>
+              <Component.default />
             </TabItem>
           );
         })}

--- a/src/scripts/generate_code_snippets.mjs
+++ b/src/scripts/generate_code_snippets.mjs
@@ -1,0 +1,91 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import * as curlconverter from "curlconverter";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const BASE_PATH = path.join(__dirname, "..", "..", "src", "snippets");
+
+const languages = ["go", "node", "php", "python", "ruby"];
+const endpoints = [
+  "auth_api",
+  "contacts_api",
+  "messages_api",
+  "templates_api",
+  "webhooks_api",
+];
+const curlDir = path.join(BASE_PATH, "curl/");
+
+const translationMethods = (snippet) => ({
+  go: () => curlconverter.toGo(snippet),
+  node: () => curlconverter.toNodeAxios(snippet),
+  php: () => curlconverter.toPhp(snippet),
+  python: () => curlconverter.toPython(snippet),
+  ruby: () => curlconverter.toRuby(snippet),
+});
+
+const readFiles = () => {
+  endpoints.map(async (endpoint) => {
+    const endpointDir = path.join(curlDir, endpoint);
+
+    try {
+      const files = await fs.readdir(endpointDir);
+
+      for (const file of files) {
+        const fileToRead = path.join(endpointDir, file);
+
+        readFile(fileToRead, endpoint, file);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  });
+};
+
+const translateSnippet = (snippet, endpoint, fileName) => {
+  const methods = translationMethods(snippet);
+  languages.map((lang) =>
+    generateSnippet(lang, methods[lang](), endpoint, fileName)
+  );
+};
+
+const generateFile = async (snippet, lang, endpoint, fileName) => {
+  const newPath = path.join(BASE_PATH, lang, endpoint, fileName);
+  try {
+    await fs.mkdir(path.dirname(newPath), { recursive: true });
+
+    await fs.writeFile(newPath, snippet);
+  } catch (err) {
+    console.error(err.message);
+  }
+};
+
+const generateSnippet = (lang, script, endpoint, fileName) => {
+  const formatSnippet = "".concat(
+    "```",
+    lang === "node" ? "js" : lang,
+    "\n",
+    script,
+    "\n",
+    "```"
+  );
+
+  generateFile(formatSnippet, lang, endpoint, fileName);
+};
+
+const readFile = async (file, endpoint, fileName) => {
+  try {
+    const contents = await fs.readFile(file, { encoding: "utf8" });
+    translateSnippet(
+      contents.replace("```bash", "").replace("```", ""),
+      endpoint,
+      fileName
+    );
+  } catch (err) {
+    console.error(err.message);
+  }
+};
+
+readFiles();

--- a/src/snippets/curl/auth_api/_get_me.mdx
+++ b/src/snippets/curl/auth_api/_get_me.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/auth/me" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/contacts_api/_delete_contact.mdx
+++ b/src/snippets/curl/contacts_api/_delete_contact.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X DELETE "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/contacts_api/_get_contact.mdx
+++ b/src/snippets/curl/contacts_api/_get_contact.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8" \
+    -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+    -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/contacts_api/_get_contact_by_phone.mdx
+++ b/src/snippets/curl/contacts_api/_get_contact_by_phone.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/contacts/phone/5790372023" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/contacts_api/_get_contacts.mdx
+++ b/src/snippets/curl/contacts_api/_get_contacts.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/contacts" \
+    -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+    -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/contacts_api/_patch_contacts.mdx
+++ b/src/snippets/curl/contacts_api/_patch_contacts.mdx
@@ -1,0 +1,6 @@
+```bash
+  curl -X PATCH "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8" \
+      -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+      -H "Content-Type: application/json"
+      -d '{"name": "Joe Doe NEW"}'
+```

--- a/src/snippets/curl/contacts_api/_post_contacts.mdx
+++ b/src/snippets/curl/contacts_api/_post_contacts.mdx
@@ -1,0 +1,10 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8" \
+    -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+    -H "Content-Type: application/json"
+    -d '{
+        "source": "whatsapp",
+        "identifier": "123456789",
+        "name": "John Doe"
+    }'
+```

--- a/src/snippets/curl/messages_api/_get_message_status.mdx
+++ b/src/snippets/curl/messages_api/_get_message_status.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+```

--- a/src/snippets/curl/messages_api/_get_messages.mdx
+++ b/src/snippets/curl/messages_api/_get_messages.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/messages_api/_post_messages.mdx
+++ b/src/snippets/curl/messages_api/_post_messages.mdx
@@ -1,0 +1,13 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "text",
+    "content": {
+      "text": "Hello!"
+    }
+  }'
+```

--- a/src/snippets/curl/messages_api/_post_messages_audio.mdx
+++ b/src/snippets/curl/messages_api/_post_messages_audio.mdx
@@ -1,0 +1,13 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_audio.mp3"
+    }
+  }'
+```

--- a/src/snippets/curl/messages_api/_post_messages_document.mdx
+++ b/src/snippets/curl/messages_api/_post_messages_document.mdx
@@ -1,0 +1,13 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_image.pdf"
+    }
+  }'
+```

--- a/src/snippets/curl/messages_api/_post_messages_image.mdx
+++ b/src/snippets/curl/messages_api/_post_messages_image.mdx
@@ -1,0 +1,13 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "url": "https://example.com/my_image.jpeg"
+    }
+  }'
+```

--- a/src/snippets/curl/messages_api/_post_messages_image_caption.mdx
+++ b/src/snippets/curl/messages_api/_post_messages_image_caption.mdx
@@ -1,0 +1,14 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "url": "https://example.com/my_image.jpeg",
+      "text: "This is my caption"
+    }
+  }'
+```

--- a/src/snippets/curl/messages_api/_post_messages_template.mdx
+++ b/src/snippets/curl/messages_api/_post_messages_template.mdx
@@ -1,0 +1,15 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "text",
+    "content": {
+      "text": "John Doe"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }'
+```

--- a/src/snippets/curl/messages_api/_post_messages_template_document.mdx
+++ b/src/snippets/curl/messages_api/_post_messages_template_document.mdx
@@ -1,0 +1,16 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_document.pdf"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }'
+```

--- a/src/snippets/curl/messages_api/_post_messages_template_image.mdx
+++ b/src/snippets/curl/messages_api/_post_messages_template_image.mdx
@@ -1,0 +1,16 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_image.jpeg"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }'
+```

--- a/src/snippets/curl/messages_api/_post_messages_template_video.mdx
+++ b/src/snippets/curl/messages_api/_post_messages_template_video.mdx
@@ -1,0 +1,16 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "video",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_video.mp4"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }'
+```

--- a/src/snippets/curl/messages_api/_post_messages_video.mdx
+++ b/src/snippets/curl/messages_api/_post_messages_video.mdx
@@ -1,0 +1,13 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/messages/send" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_video.mp4"
+    }
+  }'
+```

--- a/src/snippets/curl/templates_api/_get_template.mdx
+++ b/src/snippets/curl/templates_api/_get_template.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/templates_api/_get_templates.mdx
+++ b/src/snippets/curl/templates_api/_get_templates.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/templates" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/templates_api/_patch_template.mdx
+++ b/src/snippets/curl/templates_api/_patch_template.mdx
@@ -1,0 +1,6 @@
+```bash
+curl -X PATCH "https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+  -d '{"title": New title"}'
+```

--- a/src/snippets/curl/webhooks_api/_delete_webhooks_unsubscribe.mdx
+++ b/src/snippets/curl/webhooks_api/_delete_webhooks_unsubscribe.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X DELETE "https://api.callbell.eu/v1/webhooks/unsubscribe" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/webhooks_api/_get_webhooks_events.mdx
+++ b/src/snippets/curl/webhooks_api/_get_webhooks_events.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/webhooks/events" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/curl/webhooks_api/_post_webhooks_subscribe.mdx
+++ b/src/snippets/curl/webhooks_api/_post_webhooks_subscribe.mdx
@@ -1,0 +1,9 @@
+```bash
+curl -X POST "https://api.callbell.eu/v1/webhooks/subscribe" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+  -d '{
+        "url": "https://my-app.com/my-webhook-endpoint",
+        "subscriptions": ["message_created", "contact_created"]
+  }'
+```

--- a/src/snippets/go/auth_api/_get_me.mdx
+++ b/src/snippets/go/auth_api/_get_me.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/auth/me", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/contacts_api/_delete_contact.mdx
+++ b/src/snippets/go/contacts_api/_delete_contact.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("DELETE", "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/contacts_api/_get_contact.mdx
+++ b/src/snippets/go/contacts_api/_get_contact.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/contacts_api/_get_contact_by_phone.mdx
+++ b/src/snippets/go/contacts_api/_get_contact_by_phone.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/contacts/phone/5790372023", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/contacts_api/_get_contacts.mdx
+++ b/src/snippets/go/contacts_api/_get_contacts.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/contacts", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/contacts_api/_patch_contacts.mdx
+++ b/src/snippets/go/contacts_api/_patch_contacts.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("PATCH", "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/contacts_api/_post_contacts.mdx
+++ b/src/snippets/go/contacts_api/_post_contacts.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_get_message_status.mdx
+++ b/src/snippets/go/messages_api/_get_message_status.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_get_messages.mdx
+++ b/src/snippets/go/messages_api/_get_messages.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages.mdx
+++ b/src/snippets/go/messages_api/_post_messages.mdx
@@ -1,0 +1,40 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "text",
+    "content": {
+      "text": "Hello!"
+    }
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages_audio.mdx
+++ b/src/snippets/go/messages_api/_post_messages_audio.mdx
@@ -1,0 +1,40 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_audio.mp3"
+    }
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages_document.mdx
+++ b/src/snippets/go/messages_api/_post_messages_document.mdx
@@ -1,0 +1,40 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_image.pdf"
+    }
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages_image.mdx
+++ b/src/snippets/go/messages_api/_post_messages_image.mdx
@@ -1,0 +1,40 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "url": "https://example.com/my_image.jpeg"
+    }
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages_image_caption.mdx
+++ b/src/snippets/go/messages_api/_post_messages_image_caption.mdx
@@ -1,0 +1,41 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "url": "https://example.com/my_image.jpeg",
+      "text: "This is my caption"
+    }
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages_template.mdx
+++ b/src/snippets/go/messages_api/_post_messages_template.mdx
@@ -1,0 +1,42 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "text",
+    "content": {
+      "text": "John Doe"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages_template_document.mdx
+++ b/src/snippets/go/messages_api/_post_messages_template_document.mdx
@@ -1,0 +1,43 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_document.pdf"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages_template_image.mdx
+++ b/src/snippets/go/messages_api/_post_messages_template_image.mdx
@@ -1,0 +1,43 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_image.jpeg"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages_template_video.mdx
+++ b/src/snippets/go/messages_api/_post_messages_template_video.mdx
@@ -1,0 +1,43 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "video",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_video.mp4"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/messages_api/_post_messages_video.mdx
+++ b/src/snippets/go/messages_api/_post_messages_video.mdx
@@ -1,0 +1,40 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_video.mp4"
+    }
+  }`)
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/messages/send", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/templates_api/_get_template.mdx
+++ b/src/snippets/go/templates_api/_get_template.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/templates_api/_get_templates.mdx
+++ b/src/snippets/go/templates_api/_get_templates.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/templates", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/templates_api/_patch_template.mdx
+++ b/src/snippets/go/templates_api/_patch_template.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("PATCH", "https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/webhooks_api/_delete_webhooks_unsubscribe.mdx
+++ b/src/snippets/go/webhooks_api/_delete_webhooks_unsubscribe.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("DELETE", "https://api.callbell.eu/v1/webhooks/unsubscribe", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/webhooks_api/_get_webhooks_events.mdx
+++ b/src/snippets/go/webhooks_api/_get_webhooks_events.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/webhooks/events", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/go/webhooks_api/_post_webhooks_subscribe.mdx
+++ b/src/snippets/go/webhooks_api/_post_webhooks_subscribe.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", "https://api.callbell.eu/v1/webhooks/subscribe", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/node/auth_api/_get_me.mdx
+++ b/src/snippets/node/auth_api/_get_me.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.get('https://api.callbell.eu/v1/auth/me', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/contacts_api/_delete_contact.mdx
+++ b/src/snippets/node/contacts_api/_delete_contact.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.delete('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/contacts_api/_get_contact.mdx
+++ b/src/snippets/node/contacts_api/_get_contact.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.get('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/contacts_api/_get_contact_by_phone.mdx
+++ b/src/snippets/node/contacts_api/_get_contact_by_phone.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.get('https://api.callbell.eu/v1/contacts/phone/5790372023', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/contacts_api/_get_contacts.mdx
+++ b/src/snippets/node/contacts_api/_get_contacts.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.get('https://api.callbell.eu/v1/contacts', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/contacts_api/_patch_contacts.mdx
+++ b/src/snippets/node/contacts_api/_patch_contacts.mdx
@@ -1,0 +1,15 @@
+```js
+const axios = require('axios');
+
+const response = await axios.patch(
+    'https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8',
+    '',
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/contacts_api/_post_contacts.mdx
+++ b/src/snippets/node/contacts_api/_post_contacts.mdx
@@ -1,0 +1,15 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8',
+    '',
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_get_message_status.mdx
+++ b/src/snippets/node/messages_api/_get_message_status.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.get('https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/messages_api/_get_messages.mdx
+++ b/src/snippets/node/messages_api/_get_messages.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.get('https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/messages_api/_post_messages.mdx
+++ b/src/snippets/node/messages_api/_post_messages.mdx
@@ -1,0 +1,23 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "text",\n    "content": {\n      "text": "Hello!"\n    }\n  }',
+    {
+        'to': '+31612345678',
+        'from': 'whatsapp',
+        'type': 'text',
+        'content': {
+            'text': 'Hello!'
+        }
+    },
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_post_messages_audio.mdx
+++ b/src/snippets/node/messages_api/_post_messages_audio.mdx
@@ -1,0 +1,23 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "document",\n    "content": {\n      "url": "https://example.com/my_audio.mp3"\n    }\n  }',
+    {
+        'to': '+31612345678',
+        'from': 'whatsapp',
+        'type': 'document',
+        'content': {
+            'url': 'https://example.com/my_audio.mp3'
+        }
+    },
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_post_messages_document.mdx
+++ b/src/snippets/node/messages_api/_post_messages_document.mdx
@@ -1,0 +1,23 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "document",\n    "content": {\n      "url": "https://example.com/my_image.pdf"\n    }\n  }',
+    {
+        'to': '+31612345678',
+        'from': 'whatsapp',
+        'type': 'document',
+        'content': {
+            'url': 'https://example.com/my_image.pdf'
+        }
+    },
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_post_messages_image.mdx
+++ b/src/snippets/node/messages_api/_post_messages_image.mdx
@@ -1,0 +1,23 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "image",\n    "content": {\n      "url": "https://example.com/my_image.jpeg"\n    }\n  }',
+    {
+        'to': '+31612345678',
+        'from': 'whatsapp',
+        'type': 'image',
+        'content': {
+            'url': 'https://example.com/my_image.jpeg'
+        }
+    },
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_post_messages_image_caption.mdx
+++ b/src/snippets/node/messages_api/_post_messages_image_caption.mdx
@@ -1,0 +1,15 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "image",\n    "content": {\n      "url": "https://example.com/my_image.jpeg",\n      "text: "This is my caption"\n    }\n  }',
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_post_messages_template.mdx
+++ b/src/snippets/node/messages_api/_post_messages_template.mdx
@@ -1,0 +1,25 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "text",\n    "content": {\n      "text": "John Doe"\n    },\n    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",\n    "optin_contact": true\n  }',
+    {
+        'to': '+31612345678',
+        'from': 'whatsapp',
+        'type': 'text',
+        'content': {
+            'text': 'John Doe'
+        },
+        'template_uuid': 'd980fb66fd5043d3ace1aa06ba044342',
+        'optin_contact': true
+    },
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_post_messages_template_document.mdx
+++ b/src/snippets/node/messages_api/_post_messages_template_document.mdx
@@ -1,0 +1,26 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "document",\n    "content": {\n      "text": "John Doe",\n      "url": "https://example.com/valid_document.pdf"\n    },\n    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",\n    "optin_contact": true\n  }',
+    {
+        'to': '+31612345678',
+        'from': 'whatsapp',
+        'type': 'document',
+        'content': {
+            'text': 'John Doe',
+            'url': 'https://example.com/valid_document.pdf'
+        },
+        'template_uuid': 'd980fb66fd5043d3ace1aa06ba044342',
+        'optin_contact': true
+    },
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_post_messages_template_image.mdx
+++ b/src/snippets/node/messages_api/_post_messages_template_image.mdx
@@ -1,0 +1,26 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "image",\n    "content": {\n      "text": "John Doe",\n      "url": "https://example.com/valid_image.jpeg"\n    },\n    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",\n    "optin_contact": true\n  }',
+    {
+        'to': '+31612345678',
+        'from': 'whatsapp',
+        'type': 'image',
+        'content': {
+            'text': 'John Doe',
+            'url': 'https://example.com/valid_image.jpeg'
+        },
+        'template_uuid': 'd980fb66fd5043d3ace1aa06ba044342',
+        'optin_contact': true
+    },
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_post_messages_template_video.mdx
+++ b/src/snippets/node/messages_api/_post_messages_template_video.mdx
@@ -1,0 +1,26 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "video",\n    "content": {\n      "text": "John Doe",\n      "url": "https://example.com/valid_video.mp4"\n    },\n    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",\n    "optin_contact": true\n  }',
+    {
+        'to': '+31612345678',
+        'from': 'whatsapp',
+        'type': 'video',
+        'content': {
+            'text': 'John Doe',
+            'url': 'https://example.com/valid_video.mp4'
+        },
+        'template_uuid': 'd980fb66fd5043d3ace1aa06ba044342',
+        'optin_contact': true
+    },
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/messages_api/_post_messages_video.mdx
+++ b/src/snippets/node/messages_api/_post_messages_video.mdx
@@ -1,0 +1,23 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/messages/send',
+    // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "document",\n    "content": {\n      "url": "https://example.com/my_video.mp4"\n    }\n  }',
+    {
+        'to': '+31612345678',
+        'from': 'whatsapp',
+        'type': 'document',
+        'content': {
+            'url': 'https://example.com/my_video.mp4'
+        }
+    },
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/templates_api/_get_template.mdx
+++ b/src/snippets/node/templates_api/_get_template.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.get('https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/templates_api/_get_templates.mdx
+++ b/src/snippets/node/templates_api/_get_templates.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.get('https://api.callbell.eu/v1/templates', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/templates_api/_patch_template.mdx
+++ b/src/snippets/node/templates_api/_patch_template.mdx
@@ -1,0 +1,15 @@
+```js
+const axios = require('axios');
+
+const response = await axios.patch(
+    'https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8',
+    '',
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/node/webhooks_api/_delete_webhooks_unsubscribe.mdx
+++ b/src/snippets/node/webhooks_api/_delete_webhooks_unsubscribe.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.delete('https://api.callbell.eu/v1/webhooks/unsubscribe', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/webhooks_api/_get_webhooks_events.mdx
+++ b/src/snippets/node/webhooks_api/_get_webhooks_events.mdx
@@ -1,0 +1,11 @@
+```js
+const axios = require('axios');
+
+const response = await axios.get('https://api.callbell.eu/v1/webhooks/events', {
+    headers: {
+        'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+        'Content-Type': 'application/json'
+    }
+});
+
+```

--- a/src/snippets/node/webhooks_api/_post_webhooks_subscribe.mdx
+++ b/src/snippets/node/webhooks_api/_post_webhooks_subscribe.mdx
@@ -1,0 +1,15 @@
+```js
+const axios = require('axios');
+
+const response = await axios.post(
+    'https://api.callbell.eu/v1/webhooks/subscribe',
+    '',
+    {
+        headers: {
+            'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+            'Content-Type': 'application/json'
+        }
+    }
+);
+
+```

--- a/src/snippets/php/auth_api/_get_me.mdx
+++ b/src/snippets/php/auth_api/_get_me.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/auth/me');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/contacts_api/_delete_contact.mdx
+++ b/src/snippets/php/contacts_api/_delete_contact.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/contacts_api/_get_contact.mdx
+++ b/src/snippets/php/contacts_api/_get_contact.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/contacts_api/_get_contact_by_phone.mdx
+++ b/src/snippets/php/contacts_api/_get_contact_by_phone.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/contacts/phone/5790372023');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/contacts_api/_get_contacts.mdx
+++ b/src/snippets/php/contacts_api/_get_contacts.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/contacts');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/contacts_api/_patch_contacts.mdx
+++ b/src/snippets/php/contacts_api/_patch_contacts.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/contacts_api/_post_contacts.mdx
+++ b/src/snippets/php/contacts_api/_post_contacts.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_get_message_status.mdx
+++ b/src/snippets/php/messages_api/_get_message_status.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_get_messages.mdx
+++ b/src/snippets/php/messages_api/_get_messages.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages.mdx
+++ b/src/snippets/php/messages_api/_post_messages.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages_audio.mdx
+++ b/src/snippets/php/messages_api/_post_messages_audio.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_audio.mp3\"\n    }\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages_document.mdx
+++ b/src/snippets/php/messages_api/_post_messages_document.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.pdf\"\n    }\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages_image.mdx
+++ b/src/snippets/php/messages_api/_post_messages_image.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.jpeg\"\n    }\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages_image_caption.mdx
+++ b/src/snippets/php/messages_api/_post_messages_image_caption.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.jpeg\",\n      \"text: \"This is my caption\"\n    }\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages_template.mdx
+++ b/src/snippets/php/messages_api/_post_messages_template.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"John Doe\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages_template_document.mdx
+++ b/src/snippets/php/messages_api/_post_messages_template_document.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_document.pdf\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages_template_image.mdx
+++ b/src/snippets/php/messages_api/_post_messages_template_image.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_image.jpeg\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages_template_video.mdx
+++ b/src/snippets/php/messages_api/_post_messages_template_video.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"video\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_video.mp4\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/messages_api/_post_messages_video.mdx
+++ b/src/snippets/php/messages_api/_post_messages_video.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages/send');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_video.mp4\"\n    }\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/templates_api/_get_template.mdx
+++ b/src/snippets/php/templates_api/_get_template.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/templates_api/_get_templates.mdx
+++ b/src/snippets/php/templates_api/_get_templates.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/templates');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/templates_api/_patch_template.mdx
+++ b/src/snippets/php/templates_api/_patch_template.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/webhooks_api/_delete_webhooks_unsubscribe.mdx
+++ b/src/snippets/php/webhooks_api/_delete_webhooks_unsubscribe.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/webhooks/unsubscribe');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/webhooks_api/_get_webhooks_events.mdx
+++ b/src/snippets/php/webhooks_api/_get_webhooks_events.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/webhooks/events');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/php/webhooks_api/_post_webhooks_subscribe.mdx
+++ b/src/snippets/php/webhooks_api/_post_webhooks_subscribe.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/webhooks/subscribe');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/python/auth_api/_get_me.mdx
+++ b/src/snippets/python/auth_api/_get_me.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/auth/me', headers=headers)
+
+```

--- a/src/snippets/python/contacts_api/_delete_contact.mdx
+++ b/src/snippets/python/contacts_api/_delete_contact.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.delete('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8', headers=headers)
+
+```

--- a/src/snippets/python/contacts_api/_get_contact.mdx
+++ b/src/snippets/python/contacts_api/_get_contact.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8', headers=headers)
+
+```

--- a/src/snippets/python/contacts_api/_get_contact_by_phone.mdx
+++ b/src/snippets/python/contacts_api/_get_contact_by_phone.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/contacts/phone/5790372023', headers=headers)
+
+```

--- a/src/snippets/python/contacts_api/_get_contacts.mdx
+++ b/src/snippets/python/contacts_api/_get_contacts.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/contacts', headers=headers)
+
+```

--- a/src/snippets/python/contacts_api/_patch_contacts.mdx
+++ b/src/snippets/python/contacts_api/_patch_contacts.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.patch('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8', headers=headers)
+
+```

--- a/src/snippets/python/contacts_api/_post_contacts.mdx
+++ b/src/snippets/python/contacts_api/_post_contacts.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.post('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8', headers=headers)
+
+```

--- a/src/snippets/python/messages_api/_get_message_status.mdx
+++ b/src/snippets/python/messages_api/_get_message_status.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381', headers=headers)
+
+```

--- a/src/snippets/python/messages_api/_get_messages.mdx
+++ b/src/snippets/python/messages_api/_get_messages.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381', headers=headers)
+
+```

--- a/src/snippets/python/messages_api/_post_messages.mdx
+++ b/src/snippets/python/messages_api/_post_messages.mdx
@@ -1,0 +1,25 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'to': '+31612345678',
+    'from': 'whatsapp',
+    'type': 'text',
+    'content': {
+        'text': 'Hello!',
+    },
+}
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "text",\n    "content": {\n      "text": "Hello!"\n    }\n  }'
+#response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/messages_api/_post_messages_audio.mdx
+++ b/src/snippets/python/messages_api/_post_messages_audio.mdx
@@ -1,0 +1,25 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'to': '+31612345678',
+    'from': 'whatsapp',
+    'type': 'document',
+    'content': {
+        'url': 'https://example.com/my_audio.mp3',
+    },
+}
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "document",\n    "content": {\n      "url": "https://example.com/my_audio.mp3"\n    }\n  }'
+#response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/messages_api/_post_messages_document.mdx
+++ b/src/snippets/python/messages_api/_post_messages_document.mdx
@@ -1,0 +1,25 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'to': '+31612345678',
+    'from': 'whatsapp',
+    'type': 'document',
+    'content': {
+        'url': 'https://example.com/my_image.pdf',
+    },
+}
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "document",\n    "content": {\n      "url": "https://example.com/my_image.pdf"\n    }\n  }'
+#response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/messages_api/_post_messages_image.mdx
+++ b/src/snippets/python/messages_api/_post_messages_image.mdx
@@ -1,0 +1,25 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'to': '+31612345678',
+    'from': 'whatsapp',
+    'type': 'image',
+    'content': {
+        'url': 'https://example.com/my_image.jpeg',
+    },
+}
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "image",\n    "content": {\n      "url": "https://example.com/my_image.jpeg"\n    }\n  }'
+#response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/messages_api/_post_messages_image_caption.mdx
+++ b/src/snippets/python/messages_api/_post_messages_image_caption.mdx
@@ -1,0 +1,13 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "image",\n    "content": {\n      "url": "https://example.com/my_image.jpeg",\n      "text: "This is my caption"\n    }\n  }'
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/messages_api/_post_messages_template.mdx
+++ b/src/snippets/python/messages_api/_post_messages_template.mdx
@@ -1,0 +1,27 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'to': '+31612345678',
+    'from': 'whatsapp',
+    'type': 'text',
+    'content': {
+        'text': 'John Doe',
+    },
+    'template_uuid': 'd980fb66fd5043d3ace1aa06ba044342',
+    'optin_contact': True,
+}
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "text",\n    "content": {\n      "text": "John Doe"\n    },\n    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",\n    "optin_contact": true\n  }'
+#response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/messages_api/_post_messages_template_document.mdx
+++ b/src/snippets/python/messages_api/_post_messages_template_document.mdx
@@ -1,0 +1,28 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'to': '+31612345678',
+    'from': 'whatsapp',
+    'type': 'document',
+    'content': {
+        'text': 'John Doe',
+        'url': 'https://example.com/valid_document.pdf',
+    },
+    'template_uuid': 'd980fb66fd5043d3ace1aa06ba044342',
+    'optin_contact': True,
+}
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "document",\n    "content": {\n      "text": "John Doe",\n      "url": "https://example.com/valid_document.pdf"\n    },\n    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",\n    "optin_contact": true\n  }'
+#response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/messages_api/_post_messages_template_image.mdx
+++ b/src/snippets/python/messages_api/_post_messages_template_image.mdx
@@ -1,0 +1,28 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'to': '+31612345678',
+    'from': 'whatsapp',
+    'type': 'image',
+    'content': {
+        'text': 'John Doe',
+        'url': 'https://example.com/valid_image.jpeg',
+    },
+    'template_uuid': 'd980fb66fd5043d3ace1aa06ba044342',
+    'optin_contact': True,
+}
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "image",\n    "content": {\n      "text": "John Doe",\n      "url": "https://example.com/valid_image.jpeg"\n    },\n    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",\n    "optin_contact": true\n  }'
+#response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/messages_api/_post_messages_template_video.mdx
+++ b/src/snippets/python/messages_api/_post_messages_template_video.mdx
@@ -1,0 +1,28 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'to': '+31612345678',
+    'from': 'whatsapp',
+    'type': 'video',
+    'content': {
+        'text': 'John Doe',
+        'url': 'https://example.com/valid_video.mp4',
+    },
+    'template_uuid': 'd980fb66fd5043d3ace1aa06ba044342',
+    'optin_contact': True,
+}
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "video",\n    "content": {\n      "text": "John Doe",\n      "url": "https://example.com/valid_video.mp4"\n    },\n    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",\n    "optin_contact": true\n  }'
+#response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/messages_api/_post_messages_video.mdx
+++ b/src/snippets/python/messages_api/_post_messages_video.mdx
@@ -1,0 +1,25 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'to': '+31612345678',
+    'from': 'whatsapp',
+    'type': 'document',
+    'content': {
+        'url': 'https://example.com/my_video.mp4',
+    },
+}
+
+response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "document",\n    "content": {\n      "url": "https://example.com/my_video.mp4"\n    }\n  }'
+#response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
+
+```

--- a/src/snippets/python/templates_api/_get_template.mdx
+++ b/src/snippets/python/templates_api/_get_template.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc', headers=headers)
+
+```

--- a/src/snippets/python/templates_api/_get_templates.mdx
+++ b/src/snippets/python/templates_api/_get_templates.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/templates', headers=headers)
+
+```

--- a/src/snippets/python/templates_api/_patch_template.mdx
+++ b/src/snippets/python/templates_api/_patch_template.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.patch('https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8', headers=headers)
+
+```

--- a/src/snippets/python/webhooks_api/_delete_webhooks_unsubscribe.mdx
+++ b/src/snippets/python/webhooks_api/_delete_webhooks_unsubscribe.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.delete('https://api.callbell.eu/v1/webhooks/unsubscribe', headers=headers)
+
+```

--- a/src/snippets/python/webhooks_api/_get_webhooks_events.mdx
+++ b/src/snippets/python/webhooks_api/_get_webhooks_events.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/webhooks/events', headers=headers)
+
+```

--- a/src/snippets/python/webhooks_api/_post_webhooks_subscribe.mdx
+++ b/src/snippets/python/webhooks_api/_post_webhooks_subscribe.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.post('https://api.callbell.eu/v1/webhooks/subscribe', headers=headers)
+
+```

--- a/src/snippets/ruby/auth_api/_get_me.mdx
+++ b/src/snippets/ruby/auth_api/_get_me.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/auth/me')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/contacts_api/_delete_contact.mdx
+++ b/src/snippets/ruby/contacts_api/_delete_contact.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8')
+req = Net::HTTP::Delete.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/contacts_api/_get_contact.mdx
+++ b/src/snippets/ruby/contacts_api/_get_contact.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/contacts_api/_get_contact_by_phone.mdx
+++ b/src/snippets/ruby/contacts_api/_get_contact_by_phone.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/contacts/phone/5790372023')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/contacts_api/_get_contacts.mdx
+++ b/src/snippets/ruby/contacts_api/_get_contacts.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/contacts')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/contacts_api/_patch_contacts.mdx
+++ b/src/snippets/ruby/contacts_api/_patch_contacts.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8')
+req = Net::HTTP::Patch.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/contacts_api/_post_contacts.mdx
+++ b/src/snippets/ruby/contacts_api/_post_contacts.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_get_message_status.mdx
+++ b/src/snippets/ruby/messages_api/_get_message_status.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_get_messages.mdx
+++ b/src/snippets/ruby/messages_api/_get_messages.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages.mdx
@@ -1,0 +1,28 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }"
+req.body = {
+  'to' => '+31612345678',
+  'from' => 'whatsapp',
+  'type' => 'text',
+  'content' => {
+    'text' => 'Hello!'
+  }
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages_audio.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages_audio.mdx
@@ -1,0 +1,28 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_audio.mp3\"\n    }\n  }"
+req.body = {
+  'to' => '+31612345678',
+  'from' => 'whatsapp',
+  'type' => 'document',
+  'content' => {
+    'url' => 'https://example.com/my_audio.mp3'
+  }
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages_document.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages_document.mdx
@@ -1,0 +1,28 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.pdf\"\n    }\n  }"
+req.body = {
+  'to' => '+31612345678',
+  'from' => 'whatsapp',
+  'type' => 'document',
+  'content' => {
+    'url' => 'https://example.com/my_image.pdf'
+  }
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages_image.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages_image.mdx
@@ -1,0 +1,28 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.jpeg\"\n    }\n  }"
+req.body = {
+  'to' => '+31612345678',
+  'from' => 'whatsapp',
+  'type' => 'image',
+  'content' => {
+    'url' => 'https://example.com/my_image.jpeg'
+  }
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages_image_caption.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages_image_caption.mdx
@@ -1,0 +1,18 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.jpeg\",\n      \"text: \"This is my caption\"\n    }\n  }"
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages_template.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages_template.mdx
@@ -1,0 +1,30 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"John Doe\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }"
+req.body = {
+  'to' => '+31612345678',
+  'from' => 'whatsapp',
+  'type' => 'text',
+  'content' => {
+    'text' => 'John Doe'
+  },
+  'template_uuid' => 'd980fb66fd5043d3ace1aa06ba044342',
+  'optin_contact' => true
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages_template_document.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages_template_document.mdx
@@ -1,0 +1,31 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_document.pdf\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }"
+req.body = {
+  'to' => '+31612345678',
+  'from' => 'whatsapp',
+  'type' => 'document',
+  'content' => {
+    'text' => 'John Doe',
+    'url' => 'https://example.com/valid_document.pdf'
+  },
+  'template_uuid' => 'd980fb66fd5043d3ace1aa06ba044342',
+  'optin_contact' => true
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages_template_image.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages_template_image.mdx
@@ -1,0 +1,31 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_image.jpeg\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }"
+req.body = {
+  'to' => '+31612345678',
+  'from' => 'whatsapp',
+  'type' => 'image',
+  'content' => {
+    'text' => 'John Doe',
+    'url' => 'https://example.com/valid_image.jpeg'
+  },
+  'template_uuid' => 'd980fb66fd5043d3ace1aa06ba044342',
+  'optin_contact' => true
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages_template_video.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages_template_video.mdx
@@ -1,0 +1,31 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"video\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_video.mp4\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }"
+req.body = {
+  'to' => '+31612345678',
+  'from' => 'whatsapp',
+  'type' => 'video',
+  'content' => {
+    'text' => 'John Doe',
+    'url' => 'https://example.com/valid_video.mp4'
+  },
+  'template_uuid' => 'd980fb66fd5043d3ace1aa06ba044342',
+  'optin_contact' => true
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/messages_api/_post_messages_video.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages_video.mdx
@@ -1,0 +1,28 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages/send')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_video.mp4\"\n    }\n  }"
+req.body = {
+  'to' => '+31612345678',
+  'from' => 'whatsapp',
+  'type' => 'document',
+  'content' => {
+    'url' => 'https://example.com/my_video.mp4'
+  }
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/templates_api/_get_template.mdx
+++ b/src/snippets/ruby/templates_api/_get_template.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/templates_api/_get_templates.mdx
+++ b/src/snippets/ruby/templates_api/_get_templates.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/templates')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/templates_api/_patch_template.mdx
+++ b/src/snippets/ruby/templates_api/_patch_template.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8')
+req = Net::HTTP::Patch.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/webhooks_api/_delete_webhooks_unsubscribe.mdx
+++ b/src/snippets/ruby/webhooks_api/_delete_webhooks_unsubscribe.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/webhooks/unsubscribe')
+req = Net::HTTP::Delete.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/webhooks_api/_get_webhooks_events.mdx
+++ b/src/snippets/ruby/webhooks_api/_get_webhooks_events.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/webhooks/events')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/ruby/webhooks_api/_post_webhooks_subscribe.mdx
+++ b/src/snippets/ruby/webhooks_api/_post_webhooks_subscribe.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/webhooks/subscribe')
+req = Net::HTTP::Post.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```


### PR DESCRIPTION
## Description 
In this PR we introduce multi-language code snippets for the requests

We introduces a new component `<RequestTabs />` which renders all the snippet tabs given an `endpoint` parameter and a `request` parameter.

```js
<RequestTabs endpoint='messages_api' request='post_messages' />
```

will render the following:

<img width="901" alt="image" src="https://user-images.githubusercontent.com/34379911/222503472-d5a81cf5-edc9-45c1-ac21-3c5cc960dd26.png">


We also created a script which: 
- translates `cURL` request snippets into more programming languages
- generate a file with the translated code, or update one

The above script can be used like this `yarn translate_snippets` easy peasy :fire:

We support the following languages: `cURL`, `node`, `php`, `ruby`, `go` and `python` 