### PR TITLE
chore: fix log dates format, use correct merge commit dates

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
-### 3-2022
+### April 5, 2023
 
 #### What's new
 
@@ -14,7 +14,7 @@ A list of all the changes and enhancements that were introduced in our API. Use 
 - Users can now be assigned to a contact during creation or update by providing the assigned_user parameter with a user's email (eg. `john.doe@email.com`). Ensure that the provided email corresponds to a confirmed user in your account.
 - To unassign a user from a contact during an update, include the unassign_user parameter in the request body and set its value to true. This action will remove the assigned user from the contact.
 
-### 02-2022
+### March 3, 2023
 
 #### What's New
 
@@ -27,7 +27,7 @@ A list of all the changes and enhancements that were introduced in our API. Use 
 - `custom_fields`, `tags` can be passed in the body when [creating](/api_reference/contacts_api/post_contacts) or [creating](/api_reference/contacts_api/post_contacts) a contact
 - `phone_number` of [Contact](/api_reference/object_types/contact) can't be updated anymore
 
-### 01-2023
+### January 17, 2023
 
 #### What's New
 
@@ -37,13 +37,13 @@ A list of all the changes and enhancements that were introduced in our API. Use 
 
 - Allow to send [Template Messages](/api_reference/messages_api/post_send_messages#send-template-messages)
 
-### 11-2022
+### November 11, 2022
 
 #### What's new
 
 - [Auth API](/api_reference/auth_api/introduction)
 
-### 10-2022
+### October 18, 2022
 
 #### What's new
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -8,7 +8,7 @@ A list of all the changes and enhancements that were introduced in our API. Use 
 
 ### April 5, 2023
 
-#### What's new
+#### ✨ What's new
 
 - The `assignedUser` attribute has been added to the [Contact](/api_reference/object_types/contact) object
 - Users can now be assigned to a contact during creation or update by providing the assigned_user parameter with a user's email (eg. `john.doe@email.com`). Ensure that the provided email corresponds to a confirmed user in your account.
@@ -16,12 +16,12 @@ A list of all the changes and enhancements that were introduced in our API. Use 
 
 ### March 3, 2023
 
-#### What's New
+#### ✨ What's new
 
 - Multi-language code snippets (`curl`, `node`, `go`, `ruby`, `php`, `python`) for all the requests
 - Release Notes section
 
-#### Changes
+#### 🛠️ Changes
 
 - [Contact](/api_reference/object_types/contact) now includes `custom_fields`
 - `custom_fields`, `tags` can be passed in the body when [creating](/api_reference/contacts_api/post_contacts) or [creating](/api_reference/contacts_api/post_contacts) a contact
@@ -29,22 +29,22 @@ A list of all the changes and enhancements that were introduced in our API. Use 
 
 ### January 17, 2023
 
-#### What's New
+#### ✨ What's new
 
 - [Templates API](/api_reference/template_messages_api/introduction)
 
-#### Changes
+#### 🛠️ Changes
 
 - Allow to send [Template Messages](/api_reference/messages_api/post_send_messages#send-template-messages)
 
 ### November 11, 2022
 
-#### What's new
+#### ✨ What's new
 
 - [Auth API](/api_reference/auth_api/introduction)
 
 ### October 18, 2022
 
-#### What's new
+#### ✨ What's new
 
 - [Webhooks API](/api_reference/webhooks_api/introduction)


### PR DESCRIPTION
### PR Description

This PR formats the changelog dates to easier to understand and natural. It also revises some wrong dates by using git log merge commits for the relative features.