### PR TITLE
enh: add messages-history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,8 @@ node translate.js <your_file> 'it,pt,es,fr'
 
 This sould do the job. If you have any issues, please contact the team.
 
-:::warning
+> [!NOTE]
+> The translation is not perfect, so you need to check the translation and make sure that everything is correct.
 
-The translation is not perfect, so you need to check the translation and make sure that everything is correct.
-
-The translations preview won't be available in the local development server, so you push the changes to the repository and check the preview build on Netlify.
-
-:::
+> [!CAUTION]
+> The translations preview won't be available in the local development server, so you push the changes to the repository and check the preview build on Netlify.

--- a/README.md
+++ b/README.md
@@ -56,3 +56,24 @@ $ node src/scripts/generate_code_snippets.mjs
 ```
 
 After that, you will see that other files were created in the folders for each language.
+
+### How to translate the docs
+
+We have a script that allows you to translate the docs in other languages. To do this, you need to follow these steps:
+
+1. Add your OPEN_AI_API_KEY in the file `src/scripts/translate.mjs`;
+2. Run the following command in the terminal:
+
+```node
+node translate.js <your_file> 'it,pt,es,fr'
+```
+
+This sould do the job. If you have any issues, please contact the team.
+
+:::warning
+
+The translation is not perfect, so you need to check the translation and make sure that everything is correct.
+
+The translations preview won't be available in the local development server, so you push the changes to the repository and check the preview build on Netlify.
+
+:::

--- a/docs/api/reference/contacts_api/get_contact_messages.md
+++ b/docs/api/reference/contacts_api/get_contact_messages.md
@@ -1,0 +1,60 @@
+---
+title: GET /contacts/:uuid/messages
+sidebar_position: 3
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/:uuid/messages
+
+List all messages belonging to the contact. Results are paginated and sorted by `createdAt` in descending order.
+
+### Optional Parameters
+
+| Parameter | Type    | Description                                                       |
+| :-------- | :------ | :---------------------------------------------------------------- |
+| `page`    | Integer | The page of messages. If not specified it will default to page 1. |
+
+### Example Request
+
+<RequestTabs endpoint='contacts_api' request="get_contact_messages"/>
+
+### Response
+
+| Parameter  | Type                                              | Description         |
+| :--------- | :------------------------------------------------ | :------------------ |
+| `messages` | [Messages[]](/api/reference/object_types/message) | A list of messages. |
+
+### Example Response
+
+```json title=response.json
+{
+  "messages": [
+    {
+      "text": "Hello there how can I help you?",
+      "createdAt": "2023-12-12T10:56:36Z",
+      "uuid": "cf839626ac7949879b88bcffd41d34fe",
+      "status": "sent",
+      "channel": "whatsapp",
+      "from": "391234567890",
+      "to": "390987654321"
+    },
+    {
+      "text": "Conversation was assigned to John Doe",
+      "createdAt": "2023-12-12T10:56:35Z",
+      "status": "note",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "390987654321"
+    },
+    {
+      "text": "Hello there 👋",
+      "createdAt": "2023-12-12T10:53:32Z",
+      "status": "received",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "391234567890"
+    }
+  ]
+}
+```

--- a/docs/api/reference/object_types/message.md
+++ b/docs/api/reference/object_types/message.md
@@ -1,0 +1,16 @@
+---
+title: Message
+sidebar_position: 3
+---
+
+### Message Object
+
+| Field       | Type   | Description                                          |
+| :---------- | :----- | :--------------------------------------------------- |
+| `createdAt` | string | Date of conversation creation (ISO 8601 formatted)   |
+| `uuid`      | string | Unique identifier of the message                     |
+| `text`      | string | Text of the message                                  |
+| `status`    | string | Status of the message (`sent`, `received` or `note`) |
+| `channel`   | string | Channel of the message (`whatsapp`, `telegram`, ...) |
+| `from`      | string | Sender of the message                                |
+| `to`        | string | Receiver of the message                              |

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## January 4, 2024
+
+### ✨ What's new
+
+- [Contact messages API](/api/reference/contacts_api/get_contact_messages) to fetch all the messages of a contact. This endpoint is useful to fetch all the messages of a contact, the result is paginated and sorted by date.
+
 ## December 19, 2023
 
 ### ✨ What's new

--- a/i18n/es/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
@@ -1,0 +1,60 @@
+---
+title: GET /contacts/:uuid/messages
+sidebar_position: 3
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/:uuid/messages
+
+List all messages belonging to the contact. Results are paginated and sorted by `createdAt` in descending order.
+
+### Parámetros Opcionales
+
+| Parámetro | Tipo    | Descripción                                                       |
+| :-------- | :------ | :---------------------------------------------------------------- |
+| `page`    | Integer | La página de mensajes. Si no se especifica, se utilizará la página 1. |
+
+### Ejemplo de Solicitud
+
+<RequestTabs endpoint='contacts_api' request="get_contact_messages"/>
+
+### Respuesta
+
+| Parámetro   | Tipo                                              | Descripción          |
+| :---------- | :------------------------------------------------ | :------------------- |
+| `messages`  | [Messages[]](/api/reference/object_types/message) | Una lista de mensajes. |
+
+### Ejemplo de Respuesta
+
+```json title=response.json
+{
+  "messages": [
+    {
+      "text": "Hola, ¿cómo puedo ayudarte?",
+      "createdAt": "2023-12-12T10:56:36Z",
+      "uuid": "cf839626ac7949879b88bcffd41d34fe",
+      "status": "enviado",
+      "channel": "whatsapp",
+      "from": "391234567890",
+      "to": "390987654321"
+    },
+    {
+      "text": "La conversación fue asignada a John Doe",
+      "createdAt": "2023-12-12T10:56:35Z",
+      "status": "nota",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "390987654321"
+    },
+    {
+      "text": "Hola 👋",
+      "createdAt": "2023-12-12T10:53:32Z",
+      "status": "recibido",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "391234567890"
+    }
+  ]
+}
+```

--- a/i18n/es/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
@@ -7,12 +7,12 @@ import RequestTabs from "@site/src/components/Requests/RequestTabs"
 
 # GET /contacts/:uuid/messages
 
-List all messages belonging to the contact. Results are paginated and sorted by `createdAt` in descending order.
+Lista todos los mensajes pertenecientes al contacto. Los resultados están paginados y ordenados por `createdAt` en orden descendente.
 
 ### Parámetros Opcionales
 
-| Parámetro | Tipo    | Descripción                                                       |
-| :-------- | :------ | :---------------------------------------------------------------- |
+| Parámetro | Tipo    | Descripción                                                           |
+| :-------- | :------ | :-------------------------------------------------------------------- |
 | `page`    | Integer | La página de mensajes. Si no se especifica, se utilizará la página 1. |
 
 ### Ejemplo de Solicitud
@@ -21,9 +21,9 @@ List all messages belonging to the contact. Results are paginated and sorted by 
 
 ### Respuesta
 
-| Parámetro   | Tipo                                              | Descripción          |
-| :---------- | :------------------------------------------------ | :------------------- |
-| `messages`  | [Messages[]](/api/reference/object_types/message) | Una lista de mensajes. |
+| Parámetro  | Tipo                                              | Descripción            |
+| :--------- | :------------------------------------------------ | :--------------------- |
+| `messages` | [Messages[]](/api/reference/object_types/message) | Una lista de mensajes. |
 
 ### Ejemplo de Respuesta
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -4,75 +4,81 @@ sidebar_position: 4
 
 # Notas de lançamento
 
-Uma lista de todas as alterações e melhorias que foram introduzidas em nossa API. Use-a para verificar sempre que novos endpoints forem adicionados ou alterações forem feitas.
+Uma lista de todas as mudanças e aprimoramentos que foram introduzidos em nossa API. Use-a para verificar quando novos endpoints são adicionados ou mudanças são feitas.
+
+## 4 de janeiro de 2024
+
+### ✨ O que há de novo
+
+- [API de mensagens de contato](/api/reference/contacts_api/get_contact_messages) para buscar todas as mensagens de um contato. Este endpoint é útil para buscar todas as mensagens de um contato, o resultado é paginado e ordenado por data.
 
 ## 19 de dezembro de 2023
 
 ### ✨ O que há de novo
 
-- Adicionado `team_uuid` às solicitações de [envio de mensagens](/api/reference/messages_api/post_send_messages) e criação e atualização de [contatos](/api/reference/contacts_api/post_contacts) e [contatos](/api/reference/contacts_api/patch_contacts). Isso permite atribuir um contato a uma equipe via API.
+- Adicionado `team_uuid` às solicitações de [envio de mensagens](/api/reference/messages_api/post_send_messages) e às solicitações de criação e atualização de contato [/api/reference/contacts_api/post_contacts](/api/reference/contacts_api/patch_contacts). Isso permite que você atribua um contato a uma equipe via API.
 
 ## 14 de dezembro de 2023
 
-### 🛠️ Alterações
+### 🛠️ Mudanças
 
-- O evento do Webhook de [Mensagem Criada](/api/reference/webhooks/message_events/message_created) agora inclui a referência completa do `contato`. Isso é útil para obter informações adicionais sobre o contato sem ter que realizar uma chamada de API extra.
+- O evento Webhook [Message Created](/api/reference/webhooks/message_events/message_created) agora inclui a referência completa do `contact`. Isso é útil para obter mais informações sobre o contato sem precisar fazer uma chamada extra à API.
 
 ## 30 de novembro de 2023
 
 ### ✨ O que há de novo
 
-- Evento do Webhook de [Conversa Aberta](/api/reference/webhooks/conversation_events/conversation_opened)
-- Evento do Webhook de [Conversa Fechada](/api/reference/webhooks/conversation_events/conversation_closed)
+- [Evento Webhook de Conversa Iniciada](/api/reference/webhooks/conversation_events/conversation_opened)
+- [Evento Webhook de Conversa Encerrada](/api/reference/webhooks/conversation_events/conversation_closed)
 
 ## 7 de novembro de 2023
 
 ### ✨ O que há de novo
 
-- Endpoint da API de [Equipes](/api/reference/teams_api/introduction)
+- [Endpoint da API de Equipes](/api/reference/teams_api/introduction)
 
 ## 29 de junho de 2023
 
-### 🛠️ Alterações
+### 🛠️ Mudanças
 
-- Permitir o envio de [Mensagens de Template com Múltiplas Variáveis](/api/reference/messages_api/post_send_messages#send-multi-variables-template-messages)
+- Permitir o envio de [Mensagens de Modelo Multi-Variáveis](/api/reference/messages_api/post_send_messages#send-multi-variables-template-messages)
 
 ## 15 de junho de 2023
 
 ### ✨ O que há de novo
 
-- O objeto [`MessageSendRequest`](/api/reference/object_types/message_send_request) agora inclui um novo atributo: `messageStatusPayload`. Esse atributo fornece a carga de status para a mensagem correspondente, obtida diretamente da integração.
-- Esse atributo é útil ao [recuperar atualizações de status para uma mensagem](/api/reference/messages_api/get_message_status).
-- Para fins de solução de problemas, `messageStatusPayload` também pode ser acessado via o evento de Webhook de [Atualização de Status da Mensagem](/api/reference/webhooks/message_events/message_status_updated).
+- O objeto [`MessageSendRequest`](/api/reference/object_types/message_send_request) agora inclui um novo atributo: `messageStatusPayload`. Este atributo fornece a carga de status para a mensagem correspondente, obtida diretamente da integração.
+- Esse atributo é útil ao [buscar atualizações de status para uma mensagem](/api/reference/messages_api/get_message_status).
+- Para fins de solução de problemas, `messageStatusPayload` também pode ser acessado via o [Evento Webhook de Atualização de Status da Mensagem](/api/reference/webhooks/message_events/message_status_updated).
 
 ## 5 de abril de 2023
 
 ### ✨ O que há de novo
 
-- O atributo `assignedUser` foi adicionada ao objeto [Contato](/api/reference/object_types/contact)
-- Agora é possível atribuir usuários a um contato durante a criação ou atualização, fornecendo o parâmetro `assigned_user` com o email do usuário (por exemplo, `john.doe@email.com`). Certifique-se de que o email fornecido corresponda a um usuário confirmado em sua conta.
-- Para desatribuir um usuário de um contato durante uma atualização, inclua o parâmetro `unassign_user` no corpo da solicitação e defina seu valor como true. Essa ação removerá o usuário atribuído do contato.
+- O atributo `assignedUser` foi adicionado ao objeto [Contato](/api/reference/object_types/contact).
+- Os usuários agora podem ser atribuídos a um contato durante a criação ou atualização, fornecendo o parâmetro assigned_user com o email do usuário (por exemplo, `john.doe@email.com`). Certifique-se de que o email fornecido corresponda a um usuário confirmado em sua conta.
+- Para desatribuir um usuário de um contato durante uma atualização, inclua o parâmetro unassign_user no corpo da solicitação e defina seu valor como true. Essa ação removerá o usuário atribuído do contato.
 
 ## 3 de março de 2023
 
 ### ✨ O que há de novo
 
-- Trechos de código multi-idiomas (`curl`, `node`, `go`, `ruby`, `php`, `python`) para todas as solicitações
+- Trechos de código em vários idiomas (`curl`, `node`, `go`, `ruby`, `php`, `python`) para todas as solicitações.
 - Seção de Notas de Lançamento
 
-### 🛠️ Alterações
+### 🛠️ Mudanças
 
 - [Contato](/api/reference/object_types/contact) agora inclui `custom_fields`
-- `custom_fields`, `tags` podem ser passados no corpo ao [criar](/api/reference/contacts_api/post_contacts) ou [atualizar](/api/reference/contacts_api/post_contacts) um contato
-- `phone_number` do [Contato](/api/reference/object_types/contact) não pode mais ser atualizado
+- `custom_fields` e `tags` podem ser passados no corpo ao [criar](/api/reference/contacts_api/post_contacts) ou [atualizar](/api/reference/contacts_api/post_contacts) um contato
+- O `phone_number` do [Contato](/api/reference/object_types/contact) não pode mais ser atualizado
 
 ## 17 de janeiro de 2023
 
 ### ✨ O que há de novo
 
-- API de [Modelos](/api/reference/template_messages_api/introduction)
+- [API de Modelos](/api/reference/template_messages_api/introduction)
 
-### 🛠️ Alterações
+### 🛠️ Mudanças
 
 - Permitir o envio de [Mensagens de Modelo](/api/reference/messages_api/post_send_messages#send-template-messages)
 
@@ -80,10 +86,10 @@ Uma lista de todas as alterações e melhorias que foram introduzidas em nossa A
 
 ### ✨ O que há de novo
 
-- API de [Autenticação](/api/reference/auth_api/introduction)
+- [API de Autenticação](/api/reference/auth_api/introduction)
 
 ## 18 de outubro de 2022
 
 ### ✨ O que há de novo
 
-- API de [Webhooks](/api/reference/webhooks_api/introduction)
+- [API de Webhooks](/api/reference/webhooks_api/introduction)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
@@ -7,31 +7,31 @@ import RequestTabs from "@site/src/components/Requests/RequestTabs"
 
 # GET /contacts/:uuid/messages
 
-List all messages belonging to the contact. Results are paginated and sorted by `createdAt` in descending order.
+Liste de tous les messages appartenant au contact. Les résultats sont paginés et triés par `createdAt` dans l'ordre décroissant.
 
-### Optional Parameters
+### Paramètres facultatifs
 
-| Parameter | Type    | Description                                                       |
-| :-------- | :------ | :---------------------------------------------------------------- |
-| `page`    | Integer | The page of messages. If not specified it will default to page 1. |
+| Parameter | Type    | Description                                                                            |
+| :-------- | :------ | :------------------------------------------------------------------------------------- |
+| `page`    | Integer | La page des messages. Si elle n'est pas spécifiée, la page 1 sera utilisée par défaut. |
 
-### Example Request
+### Exemple de demande
 
 <RequestTabs endpoint='contacts_api' request="get_contact_messages"/>
 
-### Response
+### Réponse
 
-| Parameter  | Type                                              | Description         |
-| :--------- | :------------------------------------------------ | :------------------ |
-| `messages` | [Messages[]](/api/reference/object_types/message) | A list of messages. |
+| Parameter  | Type                                              | Description            |
+| :--------- | :------------------------------------------------ | :--------------------- |
+| `messages` | [Messages[]](/api/reference/object_types/message) | Une liste de messages. |
 
-### Example Response
+### Exemple de réponse
 
 ```json title=response.json
 {
   "messages": [
     {
-      "text": "Hello there how can I help you?",
+      "text": "Bonjour, comment puis-je vous aider ?",
       "createdAt": "2023-12-12T10:56:36Z",
       "uuid": "cf839626ac7949879b88bcffd41d34fe",
       "status": "sent",
@@ -40,7 +40,7 @@ List all messages belonging to the contact. Results are paginated and sorted by 
       "to": "390987654321"
     },
     {
-      "text": "Conversation was assigned to John Doe",
+      "text": "La conversation a été assignée à John Doe",
       "createdAt": "2023-12-12T10:56:35Z",
       "status": "note",
       "channel": "whatsapp",
@@ -48,7 +48,7 @@ List all messages belonging to the contact. Results are paginated and sorted by 
       "to": "390987654321"
     },
     {
-      "text": "Hello there 👋",
+      "text": "Bonjour 👋",
       "createdAt": "2023-12-12T10:53:32Z",
       "status": "received",
       "channel": "whatsapp",

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
@@ -1,0 +1,60 @@
+---
+title: GET /contacts/:uuid/messages
+sidebar_position: 3
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/:uuid/messages
+
+List all messages belonging to the contact. Results are paginated and sorted by `createdAt` in descending order.
+
+### Optional Parameters
+
+| Parameter | Type    | Description                                                       |
+| :-------- | :------ | :---------------------------------------------------------------- |
+| `page`    | Integer | The page of messages. If not specified it will default to page 1. |
+
+### Example Request
+
+<RequestTabs endpoint='contacts_api' request="get_contact_messages"/>
+
+### Response
+
+| Parameter  | Type                                              | Description         |
+| :--------- | :------------------------------------------------ | :------------------ |
+| `messages` | [Messages[]](/api/reference/object_types/message) | A list of messages. |
+
+### Example Response
+
+```json title=response.json
+{
+  "messages": [
+    {
+      "text": "Hello there how can I help you?",
+      "createdAt": "2023-12-12T10:56:36Z",
+      "uuid": "cf839626ac7949879b88bcffd41d34fe",
+      "status": "sent",
+      "channel": "whatsapp",
+      "from": "391234567890",
+      "to": "390987654321"
+    },
+    {
+      "text": "Conversation was assigned to John Doe",
+      "createdAt": "2023-12-12T10:56:35Z",
+      "status": "note",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "390987654321"
+    },
+    {
+      "text": "Hello there 👋",
+      "createdAt": "2023-12-12T10:53:32Z",
+      "status": "received",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "391234567890"
+    }
+  ]
+}
+```

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -4,67 +4,73 @@ sidebar_position: 4
 
 # Notes de version
 
-Une liste de tous les changements et améliorations qui ont été introduits dans notre API. Utilisez-la pour vérifier lorsque de nouveaux endpoints sont ajoutés ou que des modifications sont apportées.
+Une liste de toutes les modifications et améliorations qui ont été apportées à notre API. Utilisez-la pour vérifier quand de nouveaux points de terminaison sont ajoutés ou que des modifications sont apportées.
+
+## 4 janvier 2024
+
+### ✨ Nouveautés
+
+- [API de messages de contact](/api/reference/contacts_api/get_contact_messages) pour récupérer tous les messages d'un contact. Ce point de terminaison est utile pour récupérer tous les messages d'un contact, le résultat est paginé et trié par date.
 
 ## 19 décembre 2023
 
 ### ✨ Nouveautés
 
-- Ajout de `team_uuid` aux requêtes de [envoi de message](/api/reference/messages_api/post_send_messages) et de création et de mise à jour de [contact](/api/reference/contacts_api/post_contacts) . Cela vous permet d'assigner un contact à une équipe via l'API.
+- Ajout de `team_uuid` aux demandes d'envoi de messages](/api/reference/messages_api/post_send_messages) et aux demandes de création](/api/reference/contacts_api/post_contacts) et de mise à jour](/api/reference/contacts_api/patch_contacts) d'un contact. Cela vous permet d'assigner un contact à une équipe via l'API.
 
 ## 14 décembre 2023
 
 ### 🛠️ Modifications
 
-- L'événement de webhook [Message Created](/api/reference/webhooks/message_events/message_created) inclut désormais la référence complète du `contact`. Ceci est utile pour obtenir des informations supplémentaires sur le contact sans avoir à effectuer un appel API supplémentaire.
+- [Événement de webhook de création de message](/api/reference/webhooks/message_events/message_created) inclut maintenant la référence complète du `contact`. Ceci est utile pour obtenir des informations supplémentaires sur le contact sans avoir à effectuer un appel d'API supplémentaire.
 
 ## 30 novembre 2023
 
 ### ✨ Nouveautés
 
-- Événement de webhook [Ouverture de conversation](/api/reference/webhooks/conversation_events/conversation_opened)
-- Événement de webhook [Fermeture de conversation](/api/reference/webhooks/conversation_events/conversation_closed)
+- [Événement de webhook d'ouverture de conversation](/api/reference/webhooks/conversation_events/conversation_opened)
+- [Événement de webhook de fermeture de conversation](/api/reference/webhooks/conversation_events/conversation_closed)
 
 ## 7 novembre 2023
 
 ### ✨ Nouveautés
 
-- Endpoint de l'API [Équipes](/api/reference/teams_api/introduction)
+- [Point de terminaison de l'API des équipes](/api/reference/teams_api/introduction)
 
 ## 29 juin 2023
 
 ### 🛠️ Modifications
 
-- Autoriser l'envoi de [messages de modèle à plusieurs variables](/api/reference/messages_api/post_send_messages#send-multi-variables-template-messages)
+- Autoriser l'envoi de [messages de modèles multi-variables](/api/reference/messages_api/post_send_messages#send-multi-variables-template-messages)
 
 ## 15 juin 2023
 
 ### ✨ Nouveautés
 
-- L'objet [`MessageSendRequest`](/api/reference/object_types/message_send_request) inclut désormais un nouvel attribut : `messageStatusPayload`. Cet attribut fournit la charge utile d'état pour le message correspondant, provenant directement de l'intégration.
-- Cet attribut est utile lorsque vous [récupérez les mises à jour d'état pour un message](/api/reference/messages_api/get_message_status).
-- À des fins de dépannage, `messageStatusPayload` peut également être consulté via l'événement de webhook [Message Status Update](/api/reference/webhooks/message_events/message_status_updated).
+- L'objet [`MessageSendRequest`](/api/reference/object_types/message_send_request) inclut maintenant un nouvel attribut : `messageStatusPayload`. Cet attribut fournit la charge utile d'état du message correspondant, provenant directement de l'intégration.
+- Cet attribut est utile lors de la [récupération des mises à jour d'état pour un message](/api/reference/messages_api/get_message_status).
+- À des fins de dépannage, `messageStatusPayload` peut également être récupéré via l'[événement de webhook de mise à jour d'état du message](/api/reference/webhooks/message_events/message_status_updated).
 
 ## 5 avril 2023
 
 ### ✨ Nouveautés
 
-- L'attribut `assignedUser` a été ajouté à l'objet [Contact](/api/reference/object_types/contact)
-- Les utilisateurs peuvent désormais être assignés à un contact lors de la création ou de la mise à jour en fournissant le paramètre `assigned_user` avec l'e-mail d'un utilisateur (par exemple `john.doe@example.com`). Assurez-vous que l'e-mail fourni correspond à un utilisateur confirmé dans votre compte.
+- L'attribut `assignedUser` a été ajouté à l'objet [Contact](/api/reference/object_types/contact).
+- Les utilisateurs peuvent maintenant être assignés à un contact lors de la création ou de la mise à jour en fournissant le paramètre `assigned_user` avec l'adresse e-mail d'un utilisateur (par exemple `john.doe@example.com`). Assurez-vous que l'e-mail fourni correspond à un utilisateur confirmé dans votre compte.
 - Pour désassigner un utilisateur d'un contact lors d'une mise à jour, incluez le paramètre `unassign_user` dans le corps de la requête et définissez sa valeur sur `true`. Cette action supprimera l'utilisateur assigné du contact.
 
 ## 3 mars 2023
 
 ### ✨ Nouveautés
 
-- Extraits de code multilingues (`curl`, `node`, `go`, `ruby`, `php`, `python`) pour toutes les requêtes
+- Extraits de code multilingues (`curl`, `node`, `go`, `ruby`, `php`, `python`) pour toutes les demandes
 - Section des notes de version
 
 ### 🛠️ Modifications
 
-- [Contact](/api/reference/object_types/contact) inclut désormais `custom_fields`
-- `custom_fields`, `tags` peuvent être transmis dans le corps lors de la [création](/api/reference/contacts_api/post_contacts) ou de la mise à jour d'un [contact](/api/reference/contacts_api/post_contacts)
-- Le `phone_number` du [contact](/api/reference/object_types/contact) ne peut plus être mis à jour
+- [Contact](/api/reference/object_types/contact) inclut maintenant `custom_fields`
+- Les `custom_fields` et `tags` peuvent être transmis dans le corps lors de la [création](/api/reference/contacts_api/post_contacts) ou de la [mise à jour](/api/reference/contacts_api/post_contacts) d'un contact
+- Le champ `phone_number` de [Contact](/api/reference/object_types/contact) ne peut plus être mis à jour
 
 ## 17 janvier 2023
 
@@ -74,7 +80,7 @@ Une liste de tous les changements et améliorations qui ont été introduits dan
 
 ### 🛠️ Modifications
 
-- Autoriser l'envoi de [messages de modèle](/api/reference/messages_api/post_send_messages#send-template-messages)
+- Autoriser l'envoi de [messages de modèles](/api/reference/messages_api/post_send_messages#send-template-messages)
 
 ## 11 novembre 2022
 
@@ -86,4 +92,4 @@ Une liste de tous les changements et améliorations qui ont été introduits dan
 
 ### ✨ Nouveautés
 
-- [API des webhooks](/api/reference/webhooks_api/introduction)
+- [API de webhooks](/api/reference/webhooks_api/introduction)

--- a/i18n/it/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
@@ -1,0 +1,60 @@
+---
+title: GET /contacts/:uuid/messages
+sidebar_position: 3
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/:uuid/messages
+
+Elenco di tutti i messaggi appartenenti al contatto. I risultati sono paginati e ordinati per `createdAt` in ordine decrescente.
+
+### Parametri Opzionali
+
+| Parametro | Tipo    | Descrizione                                                                                                                                                        |
+| :-------- | :------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `page`    | Integer | La pagina dei messaggi. Se non specificato, il valore predefinito è la pagina 1.                                                                                  |
+
+### Esempio di richiesta
+
+<RequestTabs endpoint='contacts_api' request="get_contact_messages"/>
+
+### Risposta
+
+| Parametro  | Tipo                                                     | Descrizione       |
+| :--------- | :------------------------------------------------------- | :---------------- |
+| `messages` | [Messages[]](/api/reference/object_types/message)         | Una lista di messaggi. |
+
+### Esempio di risposta
+
+```json title=response.json
+{
+  "messages": [
+    {
+      "text": "Ciao, come posso aiutarti?",
+      "createdAt": "2023-12-12T10:56:36Z",
+      "uuid": "cf839626ac7949879b88bcffd41d34fe",
+      "status": "inviato",
+      "channel": "whatsapp",
+      "from": "391234567890",
+      "to": "390987654321"
+    },
+    {
+      "text": "La conversazione è stata assegnata a John Doe",
+      "createdAt": "2023-12-12T10:56:35Z",
+      "status": "nota",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "390987654321"
+    },
+    {
+      "text": "Ciao 👋",
+      "createdAt": "2023-12-12T10:53:32Z",
+      "status": "ricevuto",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "391234567890"
+    }
+  ]
+}
+```

--- a/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -2,77 +2,83 @@
 sidebar_position: 4
 ---
 
-# Note di rilascio
+# Note sul rilascio
 
-Un elenco di tutte le modifiche e miglioramenti introdotti nella nostra API. Usalo per verificare quando vengono aggiunti nuovi endpoint o apportate modifiche.
+Elenca tutti i cambiamenti e gli miglioramenti introdotti nella nostra API. Utilizzala per verificare quando vengono aggiunti nuovi endpoint o apportate modifiche.
+
+## 4 gennaio 2024
+
+### ✨ Novità
+
+- [API dei messaggi di contatto](/api/reference/contacts_api/get_contact_messages) per recuperare tutti i messaggi di un contatto. Questo endpoint è utile per recuperare tutti i messaggi di un contatto, i risultati sono paginati e ordinati per data.
 
 ## 19 dicembre 2023
 
 ### ✨ Novità
 
-- Aggiunto `team_uuid` alle richieste di [invio messaggi](/api/reference/messages_api/post_send_messages) e alle richieste di [creazione](/api/reference/contacts_api/post_contacts) e [aggiornamento](/api/reference/contacts_api/patch_contacts) dei contatti. Questo ti consente di assegnare un contatto a un team tramite API.
+- Aggiunto `team_uuid` alle richieste di [invio messaggi](/api/reference/messages_api/post_send_messages) e alle richieste di [creazione](/api/reference/contacts_api/post_contacts) e [aggiornamento](/api/reference/contacts_api/patch_contacts) dei contatti. Questo ti permette di assegnare un contatto a un team tramite API.
 
 ## 14 dicembre 2023
 
-### 🛠️ Modifiche
+### 🛠️ Cambiamenti
 
-- L'evento [Messaggio creato tramite webhook](/api/reference/webhooks/message_events/message_created) ora include l'intero riferimento al contatto. Questo è utile per avere ulteriori informazioni sul contatto senza dover effettuare una chiamata API aggiuntiva.
+- L'evento webhook [Messaggio creato](/api/reference/webhooks/message_events/message_created) include ora tutto il riferimento al `contatto`. Questo è utile per avere ulteriori informazioni sul contatto senza effettuare una chiamata API aggiuntiva.
 
 ## 30 novembre 2023
 
 ### ✨ Novità
 
-- Evento webhook di apertura della conversazione: [Conversation Opened](/api/reference/webhooks/conversation_events/conversation_opened)
-- Evento webhook di chiusura della conversazione: [Conversation Closed](/api/reference/webhooks/conversation_events/conversation_closed)
+- [Evento webhook di apertura conversazione](/api/reference/webhooks/conversation_events/conversation_opened)
+- [Evento webhook di chiusura conversazione](/api/reference/webhooks/conversation_events/conversation_closed)
 
 ## 7 novembre 2023
 
 ### ✨ Novità
 
-- Endpoint API dei team: [Teams API](/api/reference/teams_api/introduction)
+- [Endpoint API dei team](/api/reference/teams_api/introduction)
 
 ## 29 giugno 2023
 
-### 🛠️ Modifiche
+### 🛠️ Cambiamenti
 
-- Possibilità di inviare [messaggi con template a variabili multiple](/api/reference/messages_api/post_send_messages#send-multi-variables-template-messages)
+- Possibilità di inviare [messaggi con template multi-variabile](/api/reference/messages_api/post_send_messages#send-multi-variables-template-messages)
 
 ## 15 giugno 2023
 
 ### ✨ Novità
 
-- L'oggetto [`MessageSendRequest`](/api/reference/object_types/message_send_request) include ora un nuovo attributo: `messageStatusPayload`. Questo attributo fornisce il payload dello stato per il messaggio corrispondente, proveniente direttamente dall'integrazione.
-- Questo attributo è utile quando si richiedono gli aggiornamenti dello stato per un messaggio: [fetching status updates for a message](/api/reference/messages_api/get_message_status).
-- A scopo di risoluzione dei problemi, `messageStatusPayload` può essere accessibile anche tramite l'evento webhook di aggiornamento dello stato del messaggio: [Message Status Update Webhook Event](/api/reference/webhooks/message_events/message_status_updated).
+- L'oggetto [`MessageSendRequest`](/api/reference/object_types/message_send_request) ora include un nuovo attributo: `messageStatusPayload`. Questo attributo fornisce il payload dello stato per il messaggio corrispondente, estratto direttamente dall'integrazione.
+- Questo attributo è utile quando si [recuperano gli aggiornamenti dello stato di un messaggio](/api/reference/messages_api/get_message_status).
+- A scopo di risoluzione dei problemi, `messageStatusPayload` può anche essere accessibile tramite l'[Evento webhook di aggiornamento stato messaggio](/api/reference/webhooks/message_events/message_status_updated).
 
 ## 5 aprile 2023
 
 ### ✨ Novità
 
-- L'attributo `assignedUser` è stato aggiunto all'oggetto [Contact](/api/reference/object_types/contact).
-- Ora è possibile assegnare un utente a un contatto durante la creazione o aggiornamento fornendo il parametro `assigned_user` con l'email dell'utente (ad esempio, `john.doe@email.com`). Assicurarsi che l'email fornita corrisponda a un utente confermato nel proprio account.
-- Per rimuovere un utente da un contatto durante un aggiornamento, includere il parametro `unassign_user` nel corpo della richiesta e impostare il suo valore su `true`. Questa azione rimuoverà l'utente assegnato dal contatto.
+- È stato aggiunto l'attributo `assignedUser` all'oggetto [Contatto](/api/reference/object_types/contact).
+- Ora è possibile assegnare utenti a un contatto durante la creazione o l'aggiornamento, fornendo il parametro `assigned_user` con l'email di un utente (ad esempio `john.doe@esempio.com`). Assicurati che l'email fornita corrisponda a un utente confermato nel tuo account.
+- Per rimuovere un utente assegnato da un contatto durante un'operazione di aggiornamento, includi il parametro `unassign_user` nel corpo della richiesta e impostane il valore su `true`. Questa azione rimuoverà l'utente assegnato dal contatto.
 
 ## 3 marzo 2023
 
 ### ✨ Novità
 
-- Snippet di codice multilingue (`curl`, `node`, `go`, `ruby`, `php`, `python`) per tutte le richieste
-- Sezione Note di rilascio
+- Frammenti di codice multilingua (`curl`, `node`, `go`, `ruby`, `php`, `python`) per tutte le richieste.
+- Sezione Note sul rilascio
 
-### 🛠️ Modifiche
+### 🛠️ Cambiamenti
 
-- L'oggetto [Contact](/api/reference/object_types/contact) include ora `custom_fields`
-- `custom_fields`, `tags` possono essere passati nel corpo della richiesta durante la [creazione](/api/reference/contacts_api/post_contacts) o [aggiornamento](/api/reference/contacts_api/post_contacts) di un contatto
-- Il campo `phone_number` dell'oggetto [Contact](/api/reference/object_types/contact) non può più essere aggiornato
+- [Contatto](/api/reference/object_types/contact) ora include `custom_fields`.
+- `custom_fields` e `tags` possono essere passati nel corpo delle richieste di [creazione](/api/reference/contacts_api/post_contacts) o [aggiornamento](/api/reference/contacts_api/patch_contacts) di un contatto.
+- Non è possibile più aggiornare il campo `phone_number` del [Contatto](/api/reference/object_types/contact).
 
 ## 17 gennaio 2023
 
 ### ✨ Novità
 
-- API dei modelli: [Templates API](/api/reference/template_messages_api/introduction)
+- [API dei template](/api/reference/template_messages_api/introduction)
 
-### 🛠️ Modifiche
+### 🛠️ Cambiamenti
 
 - Possibilità di inviare [messaggi con template](/api/reference/messages_api/post_send_messages#send-template-messages)
 
@@ -80,10 +86,10 @@ Un elenco di tutte le modifiche e miglioramenti introdotti nella nostra API. Usa
 
 ### ✨ Novità
 
-- API di autenticazione: [Auth API](/api/reference/auth_api/introduction)
+- [API di autenticazione](/api/reference/auth_api/introduction)
 
 ## 18 ottobre 2022
 
 ### ✨ Novità
 
-- API degli webhook: [Webhooks API](/api/reference/webhooks_api/introduction)
+- [API dei webhook](/api/reference/webhooks_api/introduction)

--- a/i18n/pt/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
@@ -1,0 +1,60 @@
+---
+title: GET /contacts/:uuid/messages
+sidebar_position: 3
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/:uuid/messages
+
+Listar todas as mensagens pertencentes ao contato. Os resultados são paginados e ordenados por `createdAt` em ordem decrescente.
+
+### Parâmetros opcionais
+
+| Parâmetro | Tipo    | Descrição                                                            |
+| :-------- | :------ | :------------------------------------------------------------------- |
+| `page`    | Integer | A página das mensagens. Se não especificado, será padrão para página 1. |
+
+### Exemplo de Requisição
+
+<RequestTabs endpoint='contacts_api' request="get_contact_messages"/>
+
+### Resposta
+
+| Parâmetro  | Tipo                                                    | Descrição           |
+| :--------- | :------------------------------------------------------ | :------------------ |
+| `messages` | [Mensagens[]](/api/reference/object_types/message)       | Uma lista de mensagens. |
+
+### Exemplo de Resposta
+
+```json title=response.json
+{
+  "messages": [
+    {
+      "text": "Olá, como posso ajudar?",
+      "createdAt": "2023-12-12T10:56:36Z",
+      "uuid": "cf839626ac7949879b88bcffd41d34fe",
+      "status": "enviado",
+      "channel": "whatsapp",
+      "from": "391234567890",
+      "to": "390987654321"
+    },
+    {
+      "text": "A conversa foi atribuída a John Doe",
+      "createdAt": "2023-12-12T10:56:35Z",
+      "status": "nota",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "390987654321"
+    },
+    {
+      "text": "Olá 👋",
+      "createdAt": "2023-12-12T10:53:32Z",
+      "status": "recebido",
+      "channel": "whatsapp",
+      "from": "390987654321",
+      "to": "391234567890"
+    }
+  ]
+}
+```

--- a/i18n/pt/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_messages.md
@@ -11,8 +11,8 @@ Listar todas as mensagens pertencentes ao contato. Os resultados são paginados 
 
 ### Parâmetros opcionais
 
-| Parâmetro | Tipo    | Descrição                                                            |
-| :-------- | :------ | :------------------------------------------------------------------- |
+| Parâmetro | Tipo    | Descrição                                                               |
+| :-------- | :------ | :---------------------------------------------------------------------- |
 | `page`    | Integer | A página das mensagens. Se não especificado, será padrão para página 1. |
 
 ### Exemplo de Requisição
@@ -21,9 +21,9 @@ Listar todas as mensagens pertencentes ao contato. Os resultados são paginados 
 
 ### Resposta
 
-| Parâmetro  | Tipo                                                    | Descrição           |
-| :--------- | :------------------------------------------------------ | :------------------ |
-| `messages` | [Mensagens[]](/api/reference/object_types/message)       | Uma lista de mensagens. |
+| Parâmetro  | Tipo                                               | Descrição               |
+| :--------- | :------------------------------------------------- | :---------------------- |
+| `messages` | [Mensagens[]](/api/reference/object_types/message) | Uma lista de mensagens. |
 
 ### Exemplo de Resposta
 

--- a/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -4,86 +4,92 @@ sidebar_position: 4
 
 # Notas de lançamento
 
-Uma lista de todas as mudanças e melhorias que foram introduzidas em nossa API. Use para verificar sempre que novos endpoints são adicionados ou mudanças são feitas.
+Uma lista de todas as alterações e melhorias que foram introduzidas em nossa API. Use-a para verificar sempre que novos endpoints forem adicionados ou alterações forem feitas.
 
-## 19 de dezembro de 2023
+## 4 de Janeiro de 2024
 
-### ✨ Novidades
+### ✨ O que há de novo
 
-- Adicionado `team_uuid` às solicitações de [envio de mensagem](/api/reference/messages_api/post_send_messages) e solicitações de [criação](/api/reference/contacts_api/post_contacts) e [atualização](/api/reference/contacts_api/patch_contacts) de contato. Isso permite atribuir um contato a uma equipe via API.
+- [API de mensagens de contato](/api/reference/contacts_api/get_contact_messages) para buscar todas as mensagens de um contato. Este endpoint é útil para buscar todas as mensagens de um contato, o resultado é paginado e ordenado por data.
 
-## 14 de dezembro de 2023
+## 19 de Dezembro de 2023
 
-### 🛠️ Mudanças
+### ✨ O que há de novo
 
-- O evento do webhook [Mensagem Criada](/api/reference/webhooks/message_events/message_created) agora inclui a referência completa do `contato`. Isso é útil para obter mais informações sobre o contato sem ter que realizar uma chamada extra para a API.
+- Adicionado `team_uuid` às solicitações de [envio de mensagem](/api/reference/messages_api/post_send_messages) e criação e atualização de contato nas solicitações de contato. Isso permite que você atribua um contato a uma equipe por meio da API.
 
-## 30 de novembro de 2023
+## 14 de Dezembro de 2023
 
-### ✨ Novidades
+### 🛠️ Alterações
 
-- Evento do webhook [Conversa Aberta](/api/reference/webhooks/conversation_events/conversation_opened)
-- Evento do webhook [Conversa Fechada](/api/reference/webhooks/conversation_events/conversation_closed)
+- O evento Webhook [Mensagem Criada](/api/reference/webhooks/message_events/message_created) agora inclui a referência completa do `contato`. Isso é útil para obter mais informações sobre o contato sem precisar fazer uma chamada de API extra.
 
-## 7 de novembro de 2023
+## 30 de Novembro de 2023
 
-### ✨ Novidades
+### ✨ O que há de novo
+
+- Evento Webhook [Conversa Iniciada](/api/reference/webhooks/conversation_events/conversation_opened)
+- Evento Webhook [Conversa Encerrada](/api/reference/webhooks/conversation_events/conversation_closed)
+
+## 7 de Novembro de 2023
+
+### ✨ O que há de novo
 
 - [Endpoint da API de Equipes](/api/reference/teams_api/introduction)
 
-## 29 de junho de 2023
+## 29 de Junho de 2023
 
-### 🛠️ Mudanças
+### 🛠️ Alterações
 
-- Permitir o envio de [Mensagens de Modelo com Múltiplas Variáveis](/api/reference/messages_api/post_send_messages#send-multi-variables-template-messages)
+- Permitir o envio de [Mensagens de Template com Múltiplas Variáveis](/api/reference/messages_api/post_send_messages#send-multi-variables-template-messages)
 
-## 15 de junho de 2023
+## 15 de Junho de 2023
 
-### ✨ Novidades
+### ✨ O que há de novo
 
-- O objeto [`MessageSendRequest`](/api/reference/object_types/message_send_request) agora inclui um novo atributo: `messageStatusPayload`. Esse atributo fornece o status da mensagem correspondente, obtido diretamente da integração.
-- Esse atributo é útil ao [buscar atualizações de status para uma mensagem](/api/reference/messages_api/get_message_status).
-- Para fins de solução de problemas, o `messageStatusPayload` também pode ser acessado por meio do evento do webhook [Atualização de Status da Mensagem](/api/reference/webhooks/message_events/message_status_updated).
+- O objeto [`MessageSendRequest`](/api/reference/object_types/message_send_request) agora inclui um novo atributo: `messageStatusPayload`. Este atributo fornece o payload de status para a mensagem correspondente, obtido diretamente da integração.
+- Este atributo é útil ao [buscar atualizações de status para uma mensagem](/api/reference/messages_api/get_message_status).
+- Para fins de solução de problemas, `messageStatusPayload` também pode ser acessado por meio do evento Webhook [Atualização de Status da Mensagem](/api/reference/webhooks/message_events/message_status_updated).
 
-## 5 de abril de 2023
+## 5 de Abril de 2023
 
-### ✨ Novidades
+### ✨ O que há de novo
 
-- O atributo `assignedUser` foi adicionado ao objeto [Contato](/api/reference/object_types/contact)
-- Agora é possível atribuir usuários a um contato durante a criação ou atualização, fornecendo o parâmetro `assigned_user` com o email de um usuário (por exemplo, `nome.sobrenome@email.com`). Certifique-se de que o email fornecido corresponda a um usuário confirmado em sua conta.
-- Para desatribuir um usuário de um contato durante uma atualização, inclua o parâmetro `unassign_user` no corpo da solicitação e defina seu valor como true. Essa ação removerá o usuário atribuído do contato.
+- O atributo `assignedUser` foi adicionado ao objeto [Contato](/api/reference/object_types/contact).
+- Agora, os usuários podem ser atribuídos a um contato durante a criação ou atualização, fornecendo o parâmetro `assigned_user` com o e-mail de um usuário (por exemplo, `john.doe@email.com`). Certifique-se de que o e-mail fornecido corresponda a um usuário confirmado em sua conta.
+- Para desatribuir um usuário de um contato durante uma atualização, inclua o parâmetro `unassign_user` no corpo da solicitação e defina seu valor como true. Esta ação irá remover o usuário atribuído do contato.
 
-## 3 de março de 2023
+## 3 de Março de 2023
 
-### ✨ Novidades
+### ✨ O que há de novo
 
 - Trechos de código multilíngues (`curl`, `node`, `go`, `ruby`, `php`, `python`) para todas as solicitações
 - Seção de Notas de Lançamento
 
-### 🛠️ Mudanças
+### 🛠️ Alterações
 
 - [Contato](/api/reference/object_types/contact) agora inclui `custom_fields`
 - `custom_fields`, `tags` podem ser passados no corpo ao [criar](/api/reference/contacts_api/post_contacts) ou [atualizar](/api/reference/contacts_api/post_contacts) um contato
-- O `phone_number` do [Contato](/api/reference/object_types/contact) não pode mais ser atualizado
+- `phone_number` do [Contato](/api/reference/object_types/contact) não pode mais ser atualizado
 
-## 17 de janeiro de 2023
+## 17 de Janeiro de 2023
 
-### ✨ Novidades
+### ✨ O que há de novo
 
-- [API de Modelos](/api/reference/template_messages_api/introduction)
+- [API de Templates](/api/reference/template_messages_api/introduction)
 
-### 🛠️ Mudanças
+### 🛠️ Alterações
 
-- Permitir o envio de [Mensagens de Modelo](/api/reference/messages_api/post_send_messages#send-template-messages)
+- Permitir o envio de [Mensagens de Template](/api/reference/messages_api/post_send_messages#send-template-messages)
 
-## 11 de novembro de 2022
+## 11 de Novembro de 2022
 
-### ✨ Novidades
+### ✨ O que há de novo
 
 - [API de Autenticação](/api/reference/auth_api/introduction)
 
-## 18 de outubro de 2022
+## 18 de Outubro de 2022
 
-### ✨ Novidades
+### ✨ O que há de novo
 
 - [API de Webhooks](/api/reference/webhooks_api/introduction)

--- a/src/snippets/curl/contacts_api/_get_contact_messages.mdx
+++ b/src/snippets/curl/contacts_api/_get_contact_messages.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/contacts/efd7d996470e463b89f079be6cf578ed/messages" \
+    -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+    -H "Content-Type: application/json"
+```

--- a/src/snippets/go/contacts_api/_get_contact_messages.mdx
+++ b/src/snippets/go/contacts_api/_get_contact_messages.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/contacts/efd7d996470e463b89f079be6cf578ed/messages", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/node/contacts_api/_get_contact_messages.mdx
+++ b/src/snippets/node/contacts_api/_get_contact_messages.mdx
@@ -1,0 +1,11 @@
+```js
+import axios from 'axios';
+
+const response = await axios.get('https://api.callbell.eu/v1/contacts/efd7d996470e463b89f079be6cf578ed/messages', {
+  headers: {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json'
+  }
+});
+
+```

--- a/src/snippets/php/contacts_api/_get_contact_messages.mdx
+++ b/src/snippets/php/contacts_api/_get_contact_messages.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/contacts/efd7d996470e463b89f079be6cf578ed/messages');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/python/contacts_api/_get_contact_messages.mdx
+++ b/src/snippets/python/contacts_api/_get_contact_messages.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/contacts/efd7d996470e463b89f079be6cf578ed/messages', headers=headers)
+
+```

--- a/src/snippets/ruby/contacts_api/_get_contact_messages.mdx
+++ b/src/snippets/ruby/contacts_api/_get_contact_messages.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/contacts/efd7d996470e463b89f079be6cf578ed/messages')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```


### PR DESCRIPTION
## Description

In this PR we add documentation regarding the new `/contacts/:uuid/messages` endpoint

Related PR https://github.com/callbellchat/callbell/pull/2096