### PR TITLE
docs: add documentation for `bot_status` endpoint

### DIFF
--- a/docs/api/reference/contacts_api/patch_contacts.md
+++ b/docs/api/reference/contacts_api/patch_contacts.md
@@ -17,14 +17,21 @@ Updates an existing contact.
 
 ### Optional Parameters
 
-| Parameter       | Type     | Description                                                                   |
-| :-------------- | :------- | :---------------------------------------------------------------------------- |
-| `tags`          | string[] | A list of comma-separated values (e.g `['Call back', 'Interested']`)          |
-| `custom_fields` | string{} | An object with the custom fields (e.g. `{'Billing Address': 'Main Street 1}`) |
-| `name`          | string   | The name of the contact                                                       |
-| `assigned_user` | String   | Email of the the collaborator that you want to assign to a contact            |
-| `unassign_user` | Boolean  | `true` is you want to remove the assigned collaborator from a contact         |
-| `team_uuid`     | String   | UUID of the team that you want to assign to a contact                         |
+| Parameter       | Type     | Description                                                                      |
+| :-------------- | :------- | :------------------------------------------------------------------------------- |
+| `tags`          | string[] | A list of comma-separated values (e.g `['Call back', 'Interested']`)             |
+| `custom_fields` | string{} | An object with the custom fields (e.g. `{'Billing Address': 'Main Street 1}`)    |
+| `name`          | string   | The name of the contact                                                          |
+| `assigned_user` | String   | Email of the the collaborator that you want to assign to a contact               |
+| `unassign_user` | Boolean  | `true` is you want to remove the assigned collaborator from a contact            |
+| `team_uuid`     | String   | UUID of the team that you want to assign to a contact                            |
+| `bot_status`    | String   | The status of the bot for this contact. Accepts either `bot_start` or `bot_end`. |
+
+:::info
+When passing `bot_status` make sure that the bot is enabled in your account. Visit [bots](https://dash.callbell.eu/bots) in your Callbell account to create and enable one.
+
+If you have a bot enabled, the default status is `bot_start`.
+:::
 
 :::caution
 Ensure that `custom_fields` and `tags` already exist in your account before passing them. Visit [tags](https://dash.callbell.eu/settings/tags) and [custom_fields](https://dash.callbell.eu/settings/custom_fields) in your settings for more information.

--- a/docs/api/reference/contacts_api/post_contacts.md
+++ b/docs/api/reference/contacts_api/post_contacts.md
@@ -19,13 +19,20 @@ Creates a new contact.
 
 ### Optional Parameters
 
-| Parameter       | Type     | Description                                                                                     |
-| :-------------- | :------- | :---------------------------------------------------------------------------------------------- |
-| `tags`          | String[] | A list of comma-separated values (e.g `['Call back', 'Interested']`)                            |
-| `custom_fields` | String{} | An object with the custom fields (e.g. `{'Billing Address': 'Main Street 1'}`)                  |
-| `assigned_user` | String   | Email of the user that you want to assign to a contact                                          |
-| `team_uuid`     | String   | UUID of the team that you want to assign to a contact                                           |
-| `channel_uuid`  | String   | The message will be sent from this channel (when omitted, it will use the default main channel) |
+| Parameter       | Type     | Description                                                                                             |
+| :-------------- | :------- | :------------------------------------------------------------------------------------------------------ |
+| `tags`          | String[] | A list of comma-separated values (e.g `['Call back', 'Interested']`)                                    |
+| `custom_fields` | String{} | An object with the custom fields (e.g. `{'Billing Address': 'Main Street 1'}`)                          |
+| `assigned_user` | String   | Email of the user that you want to assign to a contact                                                  |
+| `team_uuid`     | String   | UUID of the team that you want to assign to a contact                                                   |
+| `channel_uuid`  | String   | The message will be sent from this channel (when omitted, it will use the default main channel)         |
+| `bot_status`    | String   | The status of the bot for this contact. The status of the bot. Accepts either `bot_start` or `bot_end`. |
+
+:::info
+When passing `bot_status` make sure that the bot is enabled in your account. Visit [bots](https://dash.callbell.eu/bots) in your Callbell account to create and enable one.
+
+If you have a bot enabled, the default status is `bot_start` meaning that the bot will reply whenever the contact writes. If this is not the intended behavior, you can set the status to `bot_end` to stop the bot from replying to the contact. This can be useful when you want to take over the conversation manually or when you want to stop the bot from replying to the contact for any other reason.
+:::
 
 :::caution
 When passing `custom_fields` or `tags` make sure that they exist in your account. See [tags](https://dash.callbell.eu/settings/tags) and [custom_fields](https://dash.callbell.eu/settings/custom_fields) in your settings.

--- a/docs/api/reference/messages_api/post_send_messages.md
+++ b/docs/api/reference/messages_api/post_send_messages.md
@@ -30,6 +30,13 @@ After 24h without a reply from the customer, it is not possible to send regular 
 | `team_uuid`       | String  | Message will be assigned to this team                                                           |
 | `channel_uuid`    | String  | The message will be sent from this channel (when omitted, it will use the default main channel) |
 | `fields`          | String  | Comma-separated fields to be returned in the message. Supported values: `contact`               |
+| `bot_status`      | String  | The status of the bot for this contact. Accepts either `bot_start` or `bot_end`.                |
+
+:::info
+When passing `bot_status` make sure that the bot is enabled in your account. Visit [bots](https://dash.callbell.eu/bots) in your Callbell account to create and enable one.
+
+If you have a bot enabled, the default status is `bot_start` meaning that the bot will reply whenever the contact writes. If this is not the intended behavior, you can set the status to `bot_end` to stop the bot from replying to the contact. This can be useful when you want to take over the conversation manually or when you want to stop the bot from replying to the contact for any other reason.
+:::
 
 ### Example Request
 

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## May 15, 2024
+
+### ✨ What's new
+
+- [Create Contact](/api/reference/contacts_api/post_contacts), [Edit Contact](/api/reference/contacts_api/post_contacts) and [Send Message](/api/reference/messages_api/post_send_messages) endpoints now supports the `bot_status` parameter to set the status of the bot associated with a specific contact.
+
 ## March 11, 2024
 
 ### ✨ What's new

--- a/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Una lista de todos los cambios y mejoras que se han introducido en nuestra API. Úsala para verificar cuando se agregan nuevos puntos finales o se realizan cambios.
 
+## 15 de mayo de 2024
+
+### ✨ Novedades
+
+- Los puntos finales [Crear contacto](/api/reference/contacts_api/post_contacts), [Editar contacto](/api/reference/contacts_api/post_contacts) y [Enviar mensaje](/api/reference/messages_api/post_send_messages) ahora admiten el parámetro `bot_status` para establecer el estado del bot asociado a un contacto específico.
+
 ## 11 de marzo de 2024
 
 ### ✨ Novedades

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,12 +6,18 @@ sidebar_position: 4
 
 Une liste de tous les changements et améliorations qui ont été introduits dans notre API. Utilisez-la pour vérifier si de nouveaux points finaux sont ajoutés ou si des modifications sont apportées.
 
+## 15 Mai, 2024
+
+### ✨ Nouveautés
+
+- Les points de terminaison [Create Contact](/api/reference/contacts_api/post_contacts), [Edit Contact](/api/reference/contacts_api/post_contacts) et [Send Message](/api/reference/messages_api/post_send_messages) supportent désormais le paramètre `bot_status` pour définir le statut du bot associé à un contact spécifique.
+
 ## 11 mars 2024
 
-#### ✨ Nouveautés
+### ✨ Nouveautés
 
-- GET Contact Bot](/api/reference/contacts_api/get_contact_bot) pour obtenir le bot associé à un contact spécifique.
-- POST Contact Bot](/api/reference/contacts_api/post_contact_bot) pour changer le statut du bot associé à un contact spécifique.
+- GET [Contact Bot](/api/reference/contacts_api/get_contact_bot) pour obtenir le bot associé à un contact spécifique.
+- POST [Contact Bot](/api/reference/contacts_api/post_contact_bot) pour changer le statut du bot associé à un contact spécifique.
 
 ## 5 mars 2024
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Un elenco di tutte le modifiche e miglioramenti introdotti nella nostra API. Utilizzalo per controllare se sono stati aggiunti nuovi endpoint o apportate modifiche.
 
+## 15 maggio 2024
+
+### ✨ Novità
+
+- Gli endpoint [Crea contatto](/api/reference/contacts_api/post_contacts), [Modifica contatto](/api/reference/contacts_api/post_contacts) e [Invia messaggio](/api/reference/messages_api/post_send_messages) ora supportano il parametro `bot_status` per impostare lo stato del bot associato a un contatto specifico.
+
 ## 11 marzo 2024
 
 ### ✨ Novità

--- a/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Uma lista de todas as alterações e melhorias que foram introduzidas em nossa API. Use para verificar sempre que novos endpoints forem adicionados ou alterações forem feitas.
 
+## 15 de maio de 2024
+
+### ✨ Novidades
+
+- Os pontos de extremidade [Create Contact](/api/reference/contacts_api/post_contacts), [Edit Contact](/api/reference/contacts_api/post_contacts) e [Send Message](/api/reference/messages_api/post_send_messages) agora suportam o parâmetro `bot_status` para definir o status do bot associado a um contato específico.
+
 ## 11 de março de 2024
 
 ### ✨ Novidades


### PR DESCRIPTION
## PR Description

This PR implements the documentation for the methods implemented in https://github.com/callbellchat/callbell/pull/2392