### PR TITLE
enh: add csharp java rust snippets

### DIFF
--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## July 25, 2024
+
+### ✨ What's new
+
+- Added code snippets for **C#**, **Java** and **Rust**
+
 ## May 15, 2024
 
 ### ✨ What's new

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -109,7 +109,15 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ["ruby", "php"],
+        additionalLanguages: [
+          "ruby",
+          "php",
+          "go",
+          "python",
+          "csharp",
+          "java",
+          "rust",
+        ],
       },
     }),
 };

--- a/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Una lista de todos los cambios y mejoras que se han introducido en nuestra API. Úsala para verificar cuando se agregan nuevos puntos finales o se realizan cambios.
 
+## 25 de julio de 2024
+
+### Novedades
+
+- Añadidos fragmentos de código para **C#**, **Java** y **Rust**.
+
 ## 15 de mayo de 2024
 
 ### ✨ Novedades

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Une liste de tous les changements et améliorations qui ont été introduits dans notre API. Utilisez-la pour vérifier si de nouveaux points finaux sont ajoutés ou si des modifications sont apportées.
 
+## 25 juillet 2024
+
+#### ✨ Nouveautés
+
+- Ajout d'extraits de code pour **C#**, **Java** et **Rust**.
+
 ## 15 Mai, 2024
 
 ### ✨ Nouveautés

--- a/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Un elenco di tutte le modifiche e miglioramenti introdotti nella nostra API. Utilizzalo per controllare se sono stati aggiunti nuovi endpoint o apportate modifiche.
 
+## 25 luglio 2024
+
+### ✨ Novità
+
+- Aggiunti snippet di codice per **C#**, **Java** e **Rust**
+
 ## 15 maggio 2024
 
 ### ✨ Novità

--- a/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Uma lista de todas as alterações e melhorias que foram introduzidas em nossa API. Use para verificar sempre que novos endpoints forem adicionados ou alterações forem feitas.
 
+## 25 de julho de 2024
+
+### ✨ Novidades
+
+- Adicionados trechos de código para **C#**, **Java** e **Rust**
+
 ## 15 de maio de 2024
 
 ### ✨ Novidades

--- a/src/components/Requests/RequestTabs.jsx
+++ b/src/components/Requests/RequestTabs.jsx
@@ -34,6 +34,21 @@ export default function RequestTabs(props) {
       component: require(`../../snippets/python/${props.endpoint}/_${props.request}.mdx`),
       value: "Python",
     },
+    {
+      key: "csharp",
+      component: require(`../../snippets/csharp/${props.endpoint}/_${props.request}.mdx`),
+      value: "C#",
+    },
+    {
+      key: "java",
+      component: require(`../../snippets/java/${props.endpoint}/_${props.request}.mdx`),
+      value: "Java",
+    },
+    {
+      key: "rust",
+      component: require(`../../snippets/rust/${props.endpoint}/_${props.request}.mdx`),
+      value: "Rust",
+    },
   ];
 
   return (

--- a/src/scripts/generate_code_snippets.mjs
+++ b/src/scripts/generate_code_snippets.mjs
@@ -8,7 +8,17 @@ const __dirname = path.dirname(__filename);
 
 const BASE_PATH = path.join(__dirname, "..", "..", "src", "snippets");
 
-const languages = ["go", "node", "php", "python", "ruby"];
+const languages = [
+  "go",
+  "node",
+  "php",
+  "python",
+  "ruby",
+  "csharp",
+  "java",
+  "rust",
+];
+
 const endpoints = [
   "auth_api",
   "contacts_api",
@@ -26,6 +36,9 @@ const translationMethods = (snippet) => ({
   php: () => curlconverter.toPhp(snippet),
   python: () => curlconverter.toPython(snippet),
   ruby: () => curlconverter.toRuby(snippet),
+  csharp: () => curlconverter.toCSharp(snippet),
+  java: () => curlconverter.toJava(snippet),
+  rust: () => curlconverter.toRust(snippet),
 });
 
 const readFiles = () => {

--- a/src/snippets/csharp/auth_api/_get_me.mdx
+++ b/src/snippets/csharp/auth_api/_get_me.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/auth/me");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/channels_api/_get_channel.mdx
+++ b/src/snippets/csharp/channels_api/_get_channel.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/channels/7c996996fea947f4a1d5a11e7fac84db");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/channels_api/_get_channels.mdx
+++ b/src/snippets/csharp/channels_api/_get_channels.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/channels?type=whatsapp&page=1");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/channels_api/_patch_channel.mdx
+++ b/src/snippets/csharp/channels_api/_patch_channel.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Patch, "https://api.callbell.eu/v1/channels/7c996996fea947f4a1d5a11e7fac84db");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\"title\": \"New title\"}");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_delete_contact.mdx
+++ b/src/snippets/csharp/contacts_api/_delete_contact.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Delete, "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_get_contact.mdx
+++ b/src/snippets/csharp/contacts_api/_get_contact.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_get_contact_bot.mdx
+++ b/src/snippets/csharp/contacts_api/_get_contact_bot.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/bot");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_get_contact_by_phone.mdx
+++ b/src/snippets/csharp/contacts_api/_get_contact_by_phone.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/contacts/phone/5790372023");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_get_contact_messages.mdx
+++ b/src/snippets/csharp/contacts_api/_get_contact_messages.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/contacts/efd7d996470e463b89f079be6cf578ed/messages");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_get_contacts.mdx
+++ b/src/snippets/csharp/contacts_api/_get_contacts.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/contacts");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_patch_contacts.mdx
+++ b/src/snippets/csharp/contacts_api/_patch_contacts.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Patch, "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n        \"name\": \"Joe Doe NEW\",\n        \"custom_fields\": {\n          \"orderNumber\": 123,\n          \"zipCode\": \"98765430\"\n        }\n      }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_post_contact_bot.mdx
+++ b/src/snippets/csharp/contacts_api/_post_contact_bot.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/bot");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n        \"status\": \"bot_start\"\n      }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_post_contact_conversation_close.mdx
+++ b/src/snippets/csharp/contacts_api/_post_contact_conversation_close.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/conversation/close");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_post_contact_conversation_open.mdx
+++ b/src/snippets/csharp/contacts_api/_post_contact_conversation_open.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/conversation/open");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/contacts_api/_post_contacts.mdx
+++ b/src/snippets/csharp/contacts_api/_post_contacts.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/contacts");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n        \"source\": \"whatsapp\",\n        \"identifier\": \"123456789\",\n        \"name\": \"John Doe\"\n    }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_get_message_status.mdx
+++ b/src/snippets/csharp/messages_api/_get_message_status.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_get_messages.mdx
+++ b/src/snippets/csharp/messages_api/_get_messages.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_audio.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_audio.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_audio.mp3\"\n    }\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_document.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_document.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.pdf\"\n    }\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_image.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_image.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.jpeg\"\n    }\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_image_caption.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_image_caption.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.jpeg\",\n      \"text: \"This is my caption\"\n    }\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_template.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_template.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"John Doe\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_template_document.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_template_document.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_document.pdf\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_template_image.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_template_image.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_image.jpeg\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_template_video.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_template_video.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"video\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_video.mp4\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_video.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_video.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_video.mp4\"\n    }\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_messages_with_user_assignment.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages_with_user_assignment.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello! This message has an assigned user!\"\n    },\n    \"assigned_user\": \"john.doe@email.com\"\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/messages_api/_post_multi_variable_messages_template.mdx
+++ b/src/snippets/csharp/messages_api/_post_multi_variable_messages_template.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/messages/send");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"John Doe\"\n    },\n    \"template_values\": [\"Jack\", \"template\", \"Cheers\"],\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/teams_api/_get_team.mdx
+++ b/src/snippets/csharp/teams_api/_get_team.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/teams/ad42a09715814e6483b1c5debd6a2dbc");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/teams_api/_get_team_members.mdx
+++ b/src/snippets/csharp/teams_api/_get_team_members.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/teams/ad42a09715814e6483b1c5debd6a2dbc?status=available");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/teams_api/_get_teams.mdx
+++ b/src/snippets/csharp/teams_api/_get_teams.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/teams");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/teams_api/_patch_team.mdx
+++ b/src/snippets/csharp/teams_api/_patch_team.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Patch, "https://api.callbell.eu/v1/teams/414a6d692bd645ed803f2e7ce360d4c8");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\"name\": New team name\"}");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/templates_api/_get_template.mdx
+++ b/src/snippets/csharp/templates_api/_get_template.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/templates_api/_get_templates.mdx
+++ b/src/snippets/csharp/templates_api/_get_templates.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/templates");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/templates_api/_patch_template.mdx
+++ b/src/snippets/csharp/templates_api/_patch_template.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Patch, "https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\"title\": New title\"}");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/webhooks_api/_delete_webhooks_unsubscribe.mdx
+++ b/src/snippets/csharp/webhooks_api/_delete_webhooks_unsubscribe.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Delete, "https://api.callbell.eu/v1/webhooks/unsubscribe");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/webhooks_api/_get_webhooks_events.mdx
+++ b/src/snippets/csharp/webhooks_api/_get_webhooks_events.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/webhooks/events");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/csharp/webhooks_api/_post_webhooks_subscribe.mdx
+++ b/src/snippets/csharp/webhooks_api/_post_webhooks_subscribe.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.callbell.eu/v1/webhooks/subscribe");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n        \"url\": \"https://my-app.com/my-webhook-endpoint\",\n        \"subscriptions\": [\"message_created\", \"contact_created\"]\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/java/auth_api/_get_me.mdx
+++ b/src/snippets/java/auth_api/_get_me.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/auth/me");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/channels_api/_get_channel.mdx
+++ b/src/snippets/java/channels_api/_get_channel.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/channels/7c996996fea947f4a1d5a11e7fac84db");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/channels_api/_get_channels.mdx
+++ b/src/snippets/java/channels_api/_get_channels.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/channels?type=whatsapp&page=1");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/channels_api/_patch_channel.mdx
+++ b/src/snippets/java/channels_api/_patch_channel.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/channels/7c996996fea947f4a1d5a11e7fac84db");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("PATCH");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\"title\": \"New title\"}");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_delete_contact.mdx
+++ b/src/snippets/java/contacts_api/_delete_contact.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("DELETE");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_get_contact.mdx
+++ b/src/snippets/java/contacts_api/_get_contact.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_get_contact_bot.mdx
+++ b/src/snippets/java/contacts_api/_get_contact_bot.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/bot");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_get_contact_by_phone.mdx
+++ b/src/snippets/java/contacts_api/_get_contact_by_phone.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/phone/5790372023");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_get_contact_messages.mdx
+++ b/src/snippets/java/contacts_api/_get_contact_messages.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/efd7d996470e463b89f079be6cf578ed/messages");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_get_contacts.mdx
+++ b/src/snippets/java/contacts_api/_get_contacts.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_patch_contacts.mdx
+++ b/src/snippets/java/contacts_api/_patch_contacts.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("PATCH");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n        \"name\": \"Joe Doe NEW\",\n        \"custom_fields\": {\n          \"orderNumber\": 123,\n          \"zipCode\": \"98765430\"\n        }\n      }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_post_contact_bot.mdx
+++ b/src/snippets/java/contacts_api/_post_contact_bot.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/bot");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n        \"status\": \"bot_start\"\n      }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_post_contact_conversation_close.mdx
+++ b/src/snippets/java/contacts_api/_post_contact_conversation_close.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/conversation/close");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_post_contact_conversation_open.mdx
+++ b/src/snippets/java/contacts_api/_post_contact_conversation_open.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/conversation/open");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/contacts_api/_post_contacts.mdx
+++ b/src/snippets/java/contacts_api/_post_contacts.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n        \"source\": \"whatsapp\",\n        \"identifier\": \"123456789\",\n        \"name\": \"John Doe\"\n    }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_get_message_status.mdx
+++ b/src/snippets/java/messages_api/_get_message_status.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_get_messages.mdx
+++ b/src/snippets/java/messages_api/_get_messages.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages.mdx
+++ b/src/snippets/java/messages_api/_post_messages.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_audio.mdx
+++ b/src/snippets/java/messages_api/_post_messages_audio.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_audio.mp3\"\n    }\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_document.mdx
+++ b/src/snippets/java/messages_api/_post_messages_document.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.pdf\"\n    }\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_image.mdx
+++ b/src/snippets/java/messages_api/_post_messages_image.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.jpeg\"\n    }\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_image_caption.mdx
+++ b/src/snippets/java/messages_api/_post_messages_image_caption.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"url\": \"https://example.com/my_image.jpeg\",\n      \"text: \"This is my caption\"\n    }\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_template.mdx
+++ b/src/snippets/java/messages_api/_post_messages_template.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"John Doe\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_template_document.mdx
+++ b/src/snippets/java/messages_api/_post_messages_template_document.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_document.pdf\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_template_image.mdx
+++ b/src/snippets/java/messages_api/_post_messages_template_image.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"image\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_image.jpeg\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_template_video.mdx
+++ b/src/snippets/java/messages_api/_post_messages_template_video.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"video\",\n    \"content\": {\n      \"text\": \"John Doe\",\n      \"url\": \"https://example.com/valid_video.mp4\"\n    },\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_video.mdx
+++ b/src/snippets/java/messages_api/_post_messages_video.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"document\",\n    \"content\": {\n      \"url\": \"https://example.com/my_video.mp4\"\n    }\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_messages_with_user_assignment.mdx
+++ b/src/snippets/java/messages_api/_post_messages_with_user_assignment.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello! This message has an assigned user!\"\n    },\n    \"assigned_user\": \"john.doe@email.com\"\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/messages_api/_post_multi_variable_messages_template.mdx
+++ b/src/snippets/java/messages_api/_post_multi_variable_messages_template.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages/send");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"John Doe\"\n    },\n    \"template_values\": [\"Jack\", \"template\", \"Cheers\"],\n    \"template_uuid\": \"d980fb66fd5043d3ace1aa06ba044342\",\n    \"optin_contact\": true\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/teams_api/_get_team.mdx
+++ b/src/snippets/java/teams_api/_get_team.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/teams/ad42a09715814e6483b1c5debd6a2dbc");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/teams_api/_get_team_members.mdx
+++ b/src/snippets/java/teams_api/_get_team_members.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/teams/ad42a09715814e6483b1c5debd6a2dbc?status=available");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/teams_api/_get_teams.mdx
+++ b/src/snippets/java/teams_api/_get_teams.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/teams");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/teams_api/_patch_team.mdx
+++ b/src/snippets/java/teams_api/_patch_team.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/teams/414a6d692bd645ed803f2e7ce360d4c8");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("PATCH");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\"name\": New team name\"}");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/templates_api/_get_template.mdx
+++ b/src/snippets/java/templates_api/_get_template.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/templates_api/_get_templates.mdx
+++ b/src/snippets/java/templates_api/_get_templates.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/templates");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/templates_api/_patch_template.mdx
+++ b/src/snippets/java/templates_api/_patch_template.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("PATCH");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\"title\": New title\"}");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/webhooks_api/_delete_webhooks_unsubscribe.mdx
+++ b/src/snippets/java/webhooks_api/_delete_webhooks_unsubscribe.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/webhooks/unsubscribe");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("DELETE");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/webhooks_api/_get_webhooks_events.mdx
+++ b/src/snippets/java/webhooks_api/_get_webhooks_events.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/webhooks/events");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/java/webhooks_api/_post_webhooks_subscribe.mdx
+++ b/src/snippets/java/webhooks_api/_post_webhooks_subscribe.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/webhooks/subscribe");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("POST");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n        \"url\": \"https://my-app.com/my-webhook-endpoint\",\n        \"subscriptions\": [\"message_created\", \"contact_created\"]\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/rust/auth_api/_get_me.mdx
+++ b/src/snippets/rust/auth_api/_get_me.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/auth/me")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/channels_api/_get_channel.mdx
+++ b/src/snippets/rust/channels_api/_get_channel.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/channels/7c996996fea947f4a1d5a11e7fac84db")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/channels_api/_get_channels.mdx
+++ b/src/snippets/rust/channels_api/_get_channels.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/channels?type=whatsapp&page=1")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/channels_api/_patch_channel.mdx
+++ b/src/snippets/rust/channels_api/_patch_channel.mdx
@@ -1,0 +1,24 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.patch("https://api.callbell.eu/v1/channels/7c996996fea947f4a1d5a11e7fac84db")
+        .headers(headers)
+        .body("{\"title\": \"New title\"}")
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_delete_contact.mdx
+++ b/src/snippets/rust/contacts_api/_delete_contact.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.delete("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_get_contact.mdx
+++ b/src/snippets/rust/contacts_api/_get_contact.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_get_contact_bot.mdx
+++ b/src/snippets/rust/contacts_api/_get_contact_bot.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/bot")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_get_contact_by_phone.mdx
+++ b/src/snippets/rust/contacts_api/_get_contact_by_phone.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/contacts/phone/5790372023")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_get_contact_messages.mdx
+++ b/src/snippets/rust/contacts_api/_get_contact_messages.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/contacts/efd7d996470e463b89f079be6cf578ed/messages")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_get_contacts.mdx
+++ b/src/snippets/rust/contacts_api/_get_contacts.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/contacts")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_patch_contacts.mdx
+++ b/src/snippets/rust/contacts_api/_patch_contacts.mdx
@@ -1,0 +1,33 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.patch("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8")
+        .headers(headers)
+        .body(r#"
+{
+        "name": "Joe Doe NEW",
+        "custom_fields": {
+          "orderNumber": 123,
+          "zipCode": "98765430"
+        }
+      }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_post_contact_bot.mdx
+++ b/src/snippets/rust/contacts_api/_post_contact_bot.mdx
@@ -1,0 +1,29 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/bot")
+        .headers(headers)
+        .body(r#"
+{
+        "status": "bot_start"
+      }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_post_contact_conversation_close.mdx
+++ b/src/snippets/rust/contacts_api/_post_contact_conversation_close.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/conversation/close")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_post_contact_conversation_open.mdx
+++ b/src/snippets/rust/contacts_api/_post_contact_conversation_open.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/contacts/414a6d692bd645ed803f2e7ce360d4c8/conversation/open")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/contacts_api/_post_contacts.mdx
+++ b/src/snippets/rust/contacts_api/_post_contacts.mdx
@@ -1,0 +1,31 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/contacts")
+        .headers(headers)
+        .body(r#"
+{
+        "source": "whatsapp",
+        "identifier": "123456789",
+        "name": "John Doe"
+    }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_get_message_status.mdx
+++ b/src/snippets/rust/messages_api/_get_message_status.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_get_messages.mdx
+++ b/src/snippets/rust/messages_api/_get_messages.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/messages/status/adf3d1216d4c4dcd908199d6700f2381")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages.mdx
+++ b/src/snippets/rust/messages_api/_post_messages.mdx
@@ -1,0 +1,34 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "text",
+    "content": {
+      "text": "Hello!"
+    }
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_audio.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_audio.mdx
@@ -1,0 +1,34 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_audio.mp3"
+    }
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_document.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_document.mdx
@@ -1,0 +1,34 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_image.pdf"
+    }
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_image.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_image.mdx
@@ -1,0 +1,34 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "url": "https://example.com/my_image.jpeg"
+    }
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_image_caption.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_image_caption.mdx
@@ -1,0 +1,35 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "url": "https://example.com/my_image.jpeg",
+      "text: "This is my caption"
+    }
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_template.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_template.mdx
@@ -1,0 +1,36 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "text",
+    "content": {
+      "text": "John Doe"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_template_document.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_template_document.mdx
@@ -1,0 +1,37 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_document.pdf"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_template_image.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_template_image.mdx
@@ -1,0 +1,37 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "image",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_image.jpeg"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_template_video.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_template_video.mdx
@@ -1,0 +1,37 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "video",
+    "content": {
+      "text": "John Doe",
+      "url": "https://example.com/valid_video.mp4"
+    },
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_video.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_video.mdx
@@ -1,0 +1,34 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "document",
+    "content": {
+      "url": "https://example.com/my_video.mp4"
+    }
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_messages_with_user_assignment.mdx
+++ b/src/snippets/rust/messages_api/_post_messages_with_user_assignment.mdx
@@ -1,0 +1,35 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "text",
+    "content": {
+      "text": "Hello! This message has an assigned user!"
+    },
+    "assigned_user": "john.doe@email.com"
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/messages_api/_post_multi_variable_messages_template.mdx
+++ b/src/snippets/rust/messages_api/_post_multi_variable_messages_template.mdx
@@ -1,0 +1,37 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/messages/send")
+        .headers(headers)
+        .body(r#"
+{
+    "to": "+31612345678",
+    "from": "whatsapp",
+    "type": "text",
+    "content": {
+      "text": "John Doe"
+    },
+    "template_values": ["Jack", "template", "Cheers"],
+    "template_uuid": "d980fb66fd5043d3ace1aa06ba044342",
+    "optin_contact": true
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/teams_api/_get_team.mdx
+++ b/src/snippets/rust/teams_api/_get_team.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/teams/ad42a09715814e6483b1c5debd6a2dbc")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/teams_api/_get_team_members.mdx
+++ b/src/snippets/rust/teams_api/_get_team_members.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/teams/ad42a09715814e6483b1c5debd6a2dbc?status=available")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/teams_api/_get_teams.mdx
+++ b/src/snippets/rust/teams_api/_get_teams.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/teams")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/teams_api/_patch_team.mdx
+++ b/src/snippets/rust/teams_api/_patch_team.mdx
@@ -1,0 +1,24 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.patch("https://api.callbell.eu/v1/teams/414a6d692bd645ed803f2e7ce360d4c8")
+        .headers(headers)
+        .body("{\"name\": New team name\"}")
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/templates_api/_get_template.mdx
+++ b/src/snippets/rust/templates_api/_get_template.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/templates/ad42a09715814e6483b1c5debd6a2dbc")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/templates_api/_get_templates.mdx
+++ b/src/snippets/rust/templates_api/_get_templates.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/templates")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/templates_api/_patch_template.mdx
+++ b/src/snippets/rust/templates_api/_patch_template.mdx
@@ -1,0 +1,24 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.patch("https://api.callbell.eu/v1/templates/414a6d692bd645ed803f2e7ce360d4c8")
+        .headers(headers)
+        .body("{\"title\": New title\"}")
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/webhooks_api/_delete_webhooks_unsubscribe.mdx
+++ b/src/snippets/rust/webhooks_api/_delete_webhooks_unsubscribe.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.delete("https://api.callbell.eu/v1/webhooks/unsubscribe")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/webhooks_api/_get_webhooks_events.mdx
+++ b/src/snippets/rust/webhooks_api/_get_webhooks_events.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/webhooks/events")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```

--- a/src/snippets/rust/webhooks_api/_post_webhooks_subscribe.mdx
+++ b/src/snippets/rust/webhooks_api/_post_webhooks_subscribe.mdx
@@ -1,0 +1,30 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.post("https://api.callbell.eu/v1/webhooks/subscribe")
+        .headers(headers)
+        .body(r#"
+{
+        "url": "https://my-app.com/my-webhook-endpoint",
+        "subscriptions": ["message_created", "contact_created"]
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
slack thread: https://callbellworkspace.slack.com/archives/C047AFT8PAQ/p1721665139415299

## PR Description

A customer asked for C# snippets in the docs; given that C# is a [very popular language](https://survey.stackoverflow.co/2024/technology/) I've decided to generate / translate the existing cURL thanks to the nodeJS script called `generate_code_snippets.mjs` inside the `scripts` folders and expose them inside the tab:

<img width="1606" alt="image" src="https://github.com/user-attachments/assets/a1db912f-4c83-4a20-a38e-06e7e154e8b9">

As evident in the picture, I also took the chance to add **Java** (still very popular) and **Rust** (very young but also more and more used).
