### PR TITLE
enh: channel UUID mandatory

### DIFF
--- a/docs/api/reference/messages_api/post_send_messages.md
+++ b/docs/api/reference/messages_api/post_send_messages.md
@@ -12,12 +12,13 @@ After 24h without a reply from the customer, it is not possible to send regular 
 
 ### Required Parameters
 
-| Parameter | Type           | Description                          |
-| :-------- | :------------- | :----------------------------------- |
-| `to`      | String         | Phone number or platform identifier  |
-| `from`    | String         | Channel identifier (e.g. `whatsapp`) |
-| `type`    | MessageType    | Type of message to be sent           |
-| `content` | MessageContent | Content of the message               |
+| Parameter         | Type           | Description                                |
+| :---------------- | :------------- | :----------------------------------------- |
+| `to`              | String         | Phone number or platform identifier        |
+| `from`            | String         | Channel identifier (e.g. `whatsapp`)       |
+| `type`            | MessageType    | Type of message to be sent                 |
+| `content`         | MessageContent | Content of the message                     |
+| `channel_uuid`    | String         | The message will be sent from this channel |
 
 ### Optional Parameters
 
@@ -28,7 +29,6 @@ After 24h without a reply from the customer, it is not possible to send regular 
 | `template_values` | Array   | Values for multi-variable template message                                                      |
 | `assigned_user`   | String  | Message will be assigned to this collaborator's email                                           |
 | `team_uuid`       | String  | Message will be assigned to this team                                                           |
-| `channel_uuid`    | String  | The message will be sent from this channel (when omitted, it will use the default main channel) |
 | `fields`          | String  | Comma-separated fields to be returned in the message. Supported values: `contact,conversation`  |
 | `bot_status`      | String  | The status of the bot for this contact. Accepts either `bot_start` or `bot_end`.                |
 | `metadata`        | Object  | Metadata to be attached to the message.                                                         |

--- a/src/snippets/csharp/messages_api/_post_messages.mdx
+++ b/src/snippets/csharp/messages_api/_post_messages.mdx
@@ -8,7 +8,7 @@ HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://ap
 
 request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
 
-request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }");
+request.Content = new StringContent("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"channel_uuid\": \"35f6f8cc-b550-4278-a2ea-099f3a4e0730\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }");
 request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
 HttpResponseMessage response = await client.SendAsync(request);

--- a/src/snippets/curl/messages_api/_post_messages.mdx
+++ b/src/snippets/curl/messages_api/_post_messages.mdx
@@ -6,6 +6,7 @@ curl -X POST "https://api.callbell.eu/v1/messages/send" \
     "to": "+31612345678",
     "from": "whatsapp",
     "type": "text",
+    "channel_uuid": "35f6f8cc-b550-4278-a2ea-099f3a4e0730",
     "content": {
       "text": "Hello!"
     }

--- a/src/snippets/go/messages_api/_post_messages.mdx
+++ b/src/snippets/go/messages_api/_post_messages.mdx
@@ -15,6 +15,7 @@ func main() {
     "to": "+31612345678",
     "from": "whatsapp",
     "type": "text",
+    "channel_uuid": "35f6f8cc-b550-4278-a2ea-099f3a4e0730",
     "content": {
       "text": "Hello!"
     }

--- a/src/snippets/java/messages_api/_post_messages.mdx
+++ b/src/snippets/java/messages_api/_post_messages.mdx
@@ -18,7 +18,7 @@ class Main {
 
 		httpConn.setDoOutput(true);
 		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
-		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }");
+		writer.write("{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"channel_uuid\": \"35f6f8cc-b550-4278-a2ea-099f3a4e0730\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }");
 		writer.flush();
 		writer.close();
 		httpConn.getOutputStream().close();

--- a/src/snippets/node/messages_api/_post_messages.mdx
+++ b/src/snippets/node/messages_api/_post_messages.mdx
@@ -3,11 +3,12 @@ import axios from 'axios';
 
 const response = await axios.post(
   'https://api.callbell.eu/v1/messages/send',
-  // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "text",\n    "content": {\n      "text": "Hello!"\n    }\n  }',
+  // '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "text",\n    "channel_uuid": "35f6f8cc-b550-4278-a2ea-099f3a4e0730",\n    "content": {\n      "text": "Hello!"\n    }\n  }',
   {
     'to': '+31612345678',
     'from': 'whatsapp',
     'type': 'text',
+    'channel_uuid': '35f6f8cc-b550-4278-a2ea-099f3a4e0730',
     'content': {
       'text': 'Hello!'
     }

--- a/src/snippets/php/messages_api/_post_messages.mdx
+++ b/src/snippets/php/messages_api/_post_messages.mdx
@@ -8,7 +8,7 @@ curl_setopt($ch, CURLOPT_HTTPHEADER, [
     'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
     'Content-Type: application/json',
 ]);
-curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }");
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"channel_uuid\": \"35f6f8cc-b550-4278-a2ea-099f3a4e0730\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }");
 
 $response = curl_exec($ch);
 

--- a/src/snippets/python/messages_api/_post_messages.mdx
+++ b/src/snippets/python/messages_api/_post_messages.mdx
@@ -10,6 +10,7 @@ json_data = {
     'to': '+31612345678',
     'from': 'whatsapp',
     'type': 'text',
+    'channel_uuid': '35f6f8cc-b550-4278-a2ea-099f3a4e0730',
     'content': {
         'text': 'Hello!',
     },
@@ -19,7 +20,7 @@ response = requests.post('https://api.callbell.eu/v1/messages/send', headers=hea
 
 # Note: json_data will not be serialized by requests
 # exactly as it was in the original request.
-#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "text",\n    "content": {\n      "text": "Hello!"\n    }\n  }'
+#data = '{\n    "to": "+31612345678",\n    "from": "whatsapp",\n    "type": "text",\n    "channel_uuid": "35f6f8cc-b550-4278-a2ea-099f3a4e0730",\n    "content": {\n      "text": "Hello!"\n    }\n  }'
 #response = requests.post('https://api.callbell.eu/v1/messages/send', headers=headers, data=data)
 
 ```

--- a/src/snippets/ruby/messages_api/_post_messages.mdx
+++ b/src/snippets/ruby/messages_api/_post_messages.mdx
@@ -8,11 +8,12 @@ req.content_type = 'application/json'
 req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
 
 # The object won't be serialized exactly like this
-# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }"
+# req.body = "{\n    \"to\": \"+31612345678\",\n    \"from\": \"whatsapp\",\n    \"type\": \"text\",\n    \"channel_uuid\": \"35f6f8cc-b550-4278-a2ea-099f3a4e0730\",\n    \"content\": {\n      \"text\": \"Hello!\"\n    }\n  }"
 req.body = {
   'to' => '+31612345678',
   'from' => 'whatsapp',
   'type' => 'text',
+  'channel_uuid' => '35f6f8cc-b550-4278-a2ea-099f3a4e0730',
   'content' => {
     'text' => 'Hello!'
   }

--- a/src/snippets/rust/messages_api/_post_messages.mdx
+++ b/src/snippets/rust/messages_api/_post_messages.mdx
@@ -18,6 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "to": "+31612345678",
     "from": "whatsapp",
     "type": "text",
+    "channel_uuid": "35f6f8cc-b550-4278-a2ea-099f3a4e0730",
     "content": {
       "text": "Hello!"
     }


### PR DESCRIPTION
## PR Description
Slack thread: https://callbellworkspace.slack.com/archives/C01E7EU2KV0/p1729012499739549

The post request for sending a message does not consider `channel_uuid` as a mandatory field, so that when a message is sent without it, the message will be addressed to the main channel. However, this behavior persists even when the channel is archived.
While this is not fixed, we are updating the docs so that `channel_uuid` becomes a mandatory field when sending a message via api.