### PR TITLE
enh: adds team_uuid as optional filter

### DIFF
--- a/docs/api/reference/contacts_api/get_contacts.md
+++ b/docs/api/reference/contacts_api/get_contacts.md
@@ -11,11 +11,12 @@ List all contacts belonging to the account. A filter can be specified in order t
 
 ### Optional Parameters
 
-| Parameter | Type     | Description                                                                        |
-| :-------- | :------- | :--------------------------------------------------------------------------------- |
-| `page`    | Integer  | The page of contacts. If not specified it will default to page 1.                  |
-| `source`  | Source   | The integration type (e.g. `whatsapp`)                                             |
-| `tags`    | string[] | The matching tags, comma-separated (e.g. `sales,lead`). Tags are _case-insentive_. |
+| Parameter   | Type     | Description                                                                        |
+| :---------- | :------- | :--------------------------------------------------------------------------------- |
+| `page`      | Integer  | The page of contacts. If not specified it will default to page 1.                  |
+| `source`    | Source   | The integration type (e.g. `whatsapp`)                                             |
+| `tags`      | string[] | The matching tags, comma-separated (e.g. `sales,lead`). Tags are _case-insentive_. |
+| `team_uuid` | string   | The uuid of the team.                                                              |
 
 ### Example Request
 


### PR DESCRIPTION
## Description

This PR adds `team_uuid` as optional param on the docs.

## Screenshot

<img width="887" alt="Screenshot 2024-11-12 at 10 22 09" src="https://github.com/user-attachments/assets/9088dc13-3d76-4704-95c2-c61fdc8a474a">
