### PR TITLE
enh: interactive messages public api events

### DIFF
--- a/docs/api/reference/object_types/message_interactive_list.md
+++ b/docs/api/reference/object_types/message_interactive_list.md
@@ -1,0 +1,10 @@
+---
+title: MessageInteractiveList
+sidebar_position: 3
+---
+
+### MessageInteractiveList Object
+
+| Field      | Type     | Description                                     |
+| :--------- | :------- | :---------------------------------------------- |
+| `metadata` | string{} | Info about the interactive list message content |

--- a/docs/api/reference/object_types/message_reply_button.md
+++ b/docs/api/reference/object_types/message_reply_button.md
@@ -8,16 +8,3 @@ sidebar_position: 3
 | Field           | Type     | Description                                  |
 | :-------------- | :------- | :------------------------------------------- |
 | `metadata`      | string{} | Info about the reply buttons message         |
-| `type`          | string   | Type of message                              |
-| `content`       | string{} | Content of the reply buttons message         |
-| `url`           | string   | Url of the message attachment if present     |
-| `text`          | string   | Text of the reply buttons message            |
-| `header`        | string   | Header of the reply buttons message          |
-| `caption`       | string   | Caption of the attachment if present         |
-| `filename`      | string   | Name of the file if attachment is a document |
-| `contentType`   | string   | Type the attachment                          |
-| `options`       | string[] | Options of the reply buttons message         |
-| `type`          | string   | Type of the reply buttons option             |
-| `title`         | string   | Title of the reply buttons option            |
-| `postback_url`  | string   | Postback url of the reply buttons option     |
-| `postback_text` | string   | Postback text of the reply buttons option    |

--- a/docs/api/reference/object_types/message_reply_button.md
+++ b/docs/api/reference/object_types/message_reply_button.md
@@ -1,0 +1,23 @@
+---
+title: MessageReplyButton
+sidebar_position: 3
+---
+
+### MessageReplyButton Object
+
+| Field           | Type     | Description                                  |
+| :-------------- | :------- | :------------------------------------------- |
+| `metadata`      | string{} | Info about the reply buttons message         |
+| `type`          | string   | Type of message                              |
+| `content`       | string{} | Content of the reply buttons message         |
+| `url`           | string   | Url of the message attachment if present     |
+| `text`          | string   | Text of the reply buttons message            |
+| `header`        | string   | Header of the reply buttons message          |
+| `caption`       | string   | Caption of the attachment if present         |
+| `filename`      | string   | Name of the file if attachment is a document |
+| `contentType`   | string   | Type the attachment                          |
+| `options`       | string[] | Options of the reply buttons message         |
+| `type`          | string   | Type of the reply buttons option             |
+| `title`         | string   | Title of the reply buttons option            |
+| `postback_url`  | string   | Postback url of the reply buttons option     |
+| `postback_text` | string   | Postback text of the reply buttons option    |

--- a/docs/api/reference/webhooks/message_events/message_created.md
+++ b/docs/api/reference/webhooks/message_events/message_created.md
@@ -18,11 +18,17 @@ This event will be sent whenever a message gets **created**, for example when _r
 | `channel`                | string                                                                         | Channel identifier (e.g. `whatsapp`)                           |
 | `contact`                | [Contact](/api/reference/object_types/contact)                                 | The contact associated to the message                          |
 | `createdAt`              | string                                                                         | Date of contact creation (ISO 8601 formatted)                  |
+| `metadata`               | Object                                                                         | Metadata attached to the message (if present)                  |
+
+### Optional Fields
+
+| Field                    | Type                                                                           | Description                                                    |
+| :----------------------- | :----------------------------------------------------------------------------- | :------------------------------------------------------------- |
 | `messageContactCard`     | [MessageContactCard](/api/reference/object_types/message_contact_card)         | The contact card associated to the message                     |
 | `messageInteractiveList` | [MessageInteractiveList](/api/reference/object_types/message_interactive_list) | Interactive list message information                           |
 | `messageLocation`        | [MessageLocation](/api/reference/object_types/message_location)                | The location associated to the message                         |
 | `messageReplyButton`     | [MessageReplyButton](/api/reference/object_types/message_reply_button)         | Reply buttons message information                              |
-| `metadata`               | Object                                                                         | Metadata attached to the message (if present)                  |
+
 
 ### Example Payload
 

--- a/docs/api/reference/webhooks/message_events/message_created.md
+++ b/docs/api/reference/webhooks/message_events/message_created.md
@@ -8,19 +8,21 @@ This event will be sent whenever a message gets **created**, for example when _r
 
 ### Payload Fields
 
-| Field                | Type                                                                   | Description                                                    |
-| :------------------- | :--------------------------------------------------------------------- | :------------------------------------------------------------- |
-| `to`                 | string                                                                 | The channel-specific identifier of the message receiver        |
-| `from`               | string                                                                 | The channel-specific identifier of the message sender          |
-| `text`               | string                                                                 | The text of the message                                        |
-| `attachments`        | string[]                                                               | The attachments of the message                                 |
-| `status`             | string                                                                 | The status of the message. Can be only be `received` or `sent` |
-| `channel`            | string                                                                 | Channel identifier (e.g. `whatsapp`)                           |
-| `contact`            | [Contact](/api/reference/object_types/contact)                         | The contact associated to the message                          |
-| `createdAt`          | string                                                                 | Date of contact creation (ISO 8601 formatted)                  |
-| `messageContactCard` | [MessageContactCard](/api/reference/object_types/message_contact_card) | The contact card associated to the message                     |
-| `messageLocation`    | [MessageLocation](/api/reference/object_types/message_location)        | The location associated to the message                         |
-| `metadata`           | Object                                                                 | Metadata attached to the message (if present)                  |
+| Field                    | Type                                                                           | Description                                                    |
+| :----------------------- | :----------------------------------------------------------------------------- | :------------------------------------------------------------- |
+| `to`                     | string                                                                         | The channel-specific identifier of the message receiver        |
+| `from`                   | string                                                                         | The channel-specific identifier of the message sender          |
+| `text`                   | string                                                                         | The text of the message                                        |
+| `attachments`            | string[]                                                                       | The attachments of the message                                 |
+| `status`                 | string                                                                         | The status of the message. Can be only be `received` or `sent` |
+| `channel`                | string                                                                         | Channel identifier (e.g. `whatsapp`)                           |
+| `contact`                | [Contact](/api/reference/object_types/contact)                                 | The contact associated to the message                          |
+| `createdAt`              | string                                                                         | Date of contact creation (ISO 8601 formatted)                  |
+| `messageContactCard`     | [MessageContactCard](/api/reference/object_types/message_contact_card)         | The contact card associated to the message                     |
+| `messageInteractiveList` | [MessageInteractiveList](/api/reference/object_types/message_interactive_list) | Interactive list message information                           |
+| `messageLocation`        | [MessageLocation](/api/reference/object_types/message_location)                | The location associated to the message                         |
+| `messageReplyButton`     | [MessageReplyButton](/api/reference/object_types/message_reply_button)         | Reply buttons message information                              |
+| `metadata`               | Object                                                                         | Metadata attached to the message (if present)                  |
 
 ### Example Payload
 
@@ -57,6 +59,42 @@ This event will be sent whenever a message gets **created**, for example when _r
           ]
         }
       ]
+    },
+    "messageReplyButton": {
+      "metadata": {
+        "type": "quick_reply",
+        "content": {
+          "url": "https://url.com/uploads/conversation_attachment/url/12389/file.png",
+          "text": "hello text",
+          "header": "header",
+          "caption": "caption",
+          "filename": "file.png",
+          "contentType": "image"
+        },
+        "options": [
+          {
+            "type": "text",
+            "title": "Yes",
+            "postback_url": "",
+            "postback_text": ""
+          },
+          {
+            "type": "text",
+            "title": "No",
+            "postback_url": "",
+            "postback_text": ""
+          },
+          {
+            "type": "text",
+            "title": "Maybe",
+            "postback_url": "",
+            "postback_text": ""
+          }
+        ]
+      }
+    },
+    "messageInteractiveList": {
+      "metadata": "{\"header\":\"Welcome to our restaurant\",\"body\":\"Have a look at our menu\",\"buttons\":[{\"title\":\"click here\"}],\"sections\":[{\"title\":\"Breakfast\",\"subtitle\":null,\"items\":[{\"header\":\"Yogurt\",\"description\":null},{\"header\":\"Pancakes\",\"description\":null}]}]}"
     },
     "createdAt": "2022-10-18T12:06:29.000+02:00"
   }

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,13 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## November 19, 2024
+
+### ✨ What's new
+
+- [MessageReplyButton](/api/reference/object_types/message_reply_button) and [MessageInteractiveList](/api/reference/object_types/message_interactive_list) added as object types.
+- [Message Created Webhook event](/api/reference/webhooks/message_events/message_created) now includes the `messageReplyButton` and `messageInteractiveList` references. This is useful to have information about location messages and contact cards.
+
 ## November 18, 2024
 
 ### ✨ What's new


### PR DESCRIPTION
## PR Description
This PR updates the docs due to these changes:
https://github.com/callbellchat/callbell/pull/2953

☝️ Adds interactive lists and reply buttons messages to the webhook event payload.