### PR TITLE
enh: adds docs for note creation + new webhook events

### DIFF
--- a/docs/api/reference/contacts_api/post_contact_conversation_create_note.md
+++ b/docs/api/reference/contacts_api/post_contact_conversation_create_note.md
@@ -1,0 +1,32 @@
+---
+title: POST /contacts/:uuid/conversation/note
+sidebar_position: 11
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# POST /contacts/:uuid/conversation/note
+
+Creates a note on the conversation associated to the contact.
+
+### Required Parameters
+
+| Parameter | Type   | Description                                                                                  |
+| :-------- | :----- | :------------------------------------------------------------------------------------------- |
+| `text`    | string | The text that'll be saved as a note in the conversation. Use `@` to tag someone in the note. |
+
+### Example Request
+
+<RequestTabs endpoint='contacts_api' request="post_contact_conversation_open"/>
+
+### Response
+
+| Parameter | Type    | Description          |
+| :-------- | :------ | :------------------- |
+| `success` | Boolean | The success response |
+
+### Example Response
+
+```json title=response.json
+{ "success": true }
+```

--- a/docs/api/reference/webhooks/agent_events/agent_session_updated.md
+++ b/docs/api/reference/webhooks/agent_events/agent_session_updated.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 2
+---
+
+# Agent Session Updated
+
+The **Agent Session Updated** event is triggered whenever an agent's session changes, such as when they log in, log out, or their session expires.
+
+### Event Name
+
+`agent_session_updated`
+
+### Payload Fields
+
+| Field    | Type                                                     | Description                                                                                                |
+| :------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- |
+| `action` | string                                                   | The action type of the event. Possible actions: `user_logged_in`, `user_logged_out` or `system_logged_out` |
+| `user`   | [TeamMember](/api/reference/object_types/team_member.md) | The agent who performed the action.                                                                        |
+
+### Example Payload
+
+```json
+{
+  "event": "agent_session_updated",
+  "payload": {
+    "action": "user_logged_in",
+    "user": {
+      "email": "john.doe@gmail.com",
+      "name": "John Doe",
+      "available": false,
+      "lastUpdatedAt": "2024-02-21T12:02:47Z"
+    }
+  }
+}
+```


### PR DESCRIPTION
## Description

This PR adds the documentation on Public API for

Note creation:

![Screenshot 2024-11-21 at 11 01 10](https://github.com/user-attachments/assets/00ca22d9-efad-40d9-bb9c-dc141f461e1e)

Webhook `agent_session_updated`:

![Screenshot 2024-11-21 at 11 00 31](https://github.com/user-attachments/assets/b4f7f66f-3135-4c7e-988e-f1f6bcc28e89)
