### PR TITLE
chore: adds new blocked_at field to documentation

### DIFF
--- a/docs/api/reference/object_types/contact.md
+++ b/docs/api/reference/object_types/contact.md
@@ -11,6 +11,7 @@ sidebar_position: 1
 | `name`             | string                  | Name of contact                                   |
 | `phoneNumber`      | string                  | Phone number of the contact                       |
 | `avatarUrl`        | string                  | URL of the user avatar                            |
+| `blockedAt`        | string                  | Date of contact block (ISO 8601 formatted)        |
 | `createdAt`        | string                  | Date of contact creation (ISO 8601 formatted)     |
 | `source`           | Source                  | Source of conversation                            |
 | `closedAt`         | string                  | Date of contact closure (ISO 8601 formatted)      |

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
-## January 6, 2024
+## January 6, 2025
 
 ### ✨ What's new
 

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## January 6, 2024
+
+### ✨ What's new
+
+- Added new field `blocked_at` on [Contact](/api/reference/object_types/contact) object type.
+
 ## December 5, 2024
 
 ### ✨ What's new


### PR DESCRIPTION
## PR description

This PR adds the new `blocked_at` field to contact object type

## Screenshot

![image](https://github.com/user-attachments/assets/14b7ea25-411f-4c75-a80a-6c22f82ccbde)
