### PR TITLE
enh: webhook check response

### DIFF
--- a/docs/api/reference/webhooks/introduction.md
+++ b/docs/api/reference/webhooks/introduction.md
@@ -45,4 +45,4 @@ Callbell doesn't support `localhost` as webhook URL. If you need to debug a loca
 
 After subscribing to an event, Callbell will perform connection checks periodically.  You can answer it back with a status code of `200` and a body with `{"status": "ok"}`.
 
-If the endpoint does not respond in 6 hours, the webhook subscription will be disabled.
+If the endpoint does not respond for 10 minutes, we will send the account admin an email. If it does not respond for 6 hours, the webhook subscription will be disabled.

--- a/docs/api/reference/webhooks/introduction.md
+++ b/docs/api/reference/webhooks/introduction.md
@@ -42,3 +42,7 @@ After clicking "Create new webhook" you should receive a success notification. Y
 :::caution
 Callbell doesn't support `localhost` as webhook URL. If you need to debug a local application use instead a service to expose your local dev environment like [Ngrok](https://ngrok.com).
 :::
+
+After subscribing to an event, Callbell will perform connection checks periodically.  You can answer it back with a status code of `200` and a body with `{"status": "ok"}`.
+
+If the endpoint does not respond in 6 hours, the webhook subscription will be disabled.


### PR DESCRIPTION
Slack issue: https://callbellworkspace.slack.com/archives/C01E7EU2KV0/p1745933084463499

## PR Description
We've had a few of doubts in help-dev from customers regarding their webhooks being disconnected. Apparently they weren't aware that they had to send responses to our webhook in order to keep the connection, so we are adding this to the webhook docs.