### PR TITLE
docs: add documentation + snippets for delete message endpoint

### DIFF
--- a/docs/api/reference/messages_api/delete_message.md
+++ b/docs/api/reference/messages_api/delete_message.md
@@ -1,0 +1,30 @@
+---
+title: DELETE /messages/:uuid
+sidebar_position: 4
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# DELETE /messages/:uuid
+
+:::caution
+This endpoint will remove text and attachments **only** on Callbell. It will not affect the original message sent on the device of the customer.
+:::
+
+Deletes a message by its UUID or external ID.
+
+You can find the external ID in the `uuid` field of the [MessageSendRequest](/api/reference/object_types/message_send_request) object or by using the [GET /contacts/:uuid/messages](/api/reference/contacts_api/get_contact_messages) endpoint.
+
+### Required Parameters
+
+| Parameter | Type   | Description                                           |
+| :-------- | :----- | :---------------------------------------------------- |
+| `uuid`    | String | Identifier of the message which was sent through API. |
+
+### Example Request
+
+<RequestTabs endpoint='messages_api' request="delete_message"/>
+
+### Response
+
+API returns a 204 No Content status code on successful deletion.

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## May 20, 2025
+
+### ✨ What's new
+
+- Added [DELETE /messages/:uuid](/api/reference/messages_api/delete_message) endpoint to delete a message by its UUID or external ID.
+
 ## February 17, 2025
 
 ### ✨ What's new

--- a/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Una lista de todos los cambios y mejoras que se han introducido en nuestra API. Úsala para verificar cuando se agregan nuevos puntos finales o se realizan cambios.
 
+## 20 de mayo de 2025
+
+### ✨ Novedades
+
+- Añadido el endpoint [DELETE /messages/:uuid](/api/reference/messages_api/delete_message) para eliminar un mensaje por su UUID o ID externo.
+
 ## 17 de febrero de 2025
 
 ### ✨ Novedades

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,7 +6,13 @@ sidebar_position: 4
 
 Une liste de tous les changements et améliorations qui ont été introduits dans notre API. Utilisez-la pour vérifier si de nouveaux points finaux sont ajoutés ou si des modifications sont apportées.
 
-## February 17, 2025
+## 20 mai 2025
+
+### ✨ Nouveautés
+
+- Ajout d'un point de terminaison [DELETE /messages/:uuid](/api/reference/messages_api/delete_message) pour supprimer un message par son UUID ou ID externe.
+
+## 17 février 2025
 
 ### ✨ Nouveautés
 - Ajout d'un point de terminaison [DELETE /users/:uuid/status](/api/reference/users_api/delete_user_status) pour annuler l'attribution d'un statut personnalisé à un utilisateur.
@@ -15,28 +21,28 @@ Une liste de tous les changements et améliorations qui ont été introduits dan
 
 - Ajout de la possibilité d'annuler un statut personnalisé d'un utilisateur en passant `null` comme paramètre `custom_status_uuid` sur l'[API Utilisateurs](/api/reference/users_api/put_user_status).
 
-## February 5, 2025
+## 5 février 2025
 
 ### ✨ Nouveautés
 
 - Ajout d'un nouveau champ `emoji` sur le type d'objet [CustomStatus](/api/reference/object_types/custom_status).
 - Ajout d'informations sur [UserCustomStatus](/api/reference/object_types/user_custom_status) dans le type d'objet [TeamMember](/api/reference/object_types/team_member).
 
-## January 6, 2025
+## 6 janvier 2025
 
 ### ✨ Nouveautés
 
 - Ajout d'un nouveau champ `blocked_at` sur le type d'objet [Contact](/api/reference/object_types/contact).
 - Ajout de nouveaux champs `status`, `category` sur le type d'objet [Template Messages](/api/reference/template_messages_api/get_templates#example-response).
 
-## December 5, 2024
+## 5 décembre 2024
 
 ### ✨ Nouveautés
 
 - API de statut personnalisé](/api/reference/custom_status_api/introduction)
 - Ajout d'un nouveau point de terminaison pour [mettre à jour le statut d'un utilisateur](/docs/api/reference/users_api/put_user_status.md), ce qui signifie leur disponibilité et/ou leur statut personnalisé.
 
-## November 26, 2024
+## 26 novembre 2024
 
 ### ✨ Nouveautés
 
@@ -50,14 +56,14 @@ Une liste de tous les changements et améliorations qui ont été introduits dan
 - [MessageContext](/api/reference/object_types/message_context) et [MessageForward](/api/reference/object_types/message_forward) ajoutés en tant que types d'objets.
 - L'événement Webhook [Message Created](/api/reference/webhooks/message_events/message_created) inclut maintenant les références `messageContext` et `messageForward`. Ceci est utile pour avoir des informations sur les messages de localisation et les cartes de contact.
 
-## November 19, 2024
+## 19 novembre 2024
 
 ### ✨ Nouveautés
 
 - [MessageReplyButton](/api/reference/object_types/message_reply_button) et [MessageInteractiveList](/api/reference/object_types/message_interactive_list) ajoutés en tant que types d'objets.
 - L'événement Webhook [Message Created Webhook event](/api/reference/webhooks/message_events/message_created) inclut maintenant les références `messageReplyButton` et `messageInteractiveList`. Ceci est utile pour avoir des informations sur les messages de localisation et les cartes de contact.
 
-## November 18, 2024
+## 18 novembre 2024
 
 ### ✨ Nouveautés
 
@@ -84,7 +90,7 @@ Une liste de tous les changements et améliorations qui ont été introduits dan
 
 - Ajout d'extraits de code pour **C#**, **Java** et **Rust**.
 
-## 15 Mai, 2024
+## 15 mai 2024
 
 ### ✨ Nouveautés
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Un elenco di tutte le modifiche e miglioramenti introdotti nella nostra API. Utilizzalo per controllare se sono stati aggiunti nuovi endpoint o apportate modifiche.
 
+## 20 maggio 2025
+
+### ✨ Novità
+
+- Aggiunto l'endpoint [DELETE /messages/:uuid](/api/reference/messages_api/delete_message) per eliminare un messaggio per UUID o ID esterno.
+
 ## 17 febbraio 2025
 
 ### ✨ Novità

--- a/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Uma lista de todas as alterações e melhorias que foram introduzidas em nossa API. Use para verificar sempre que novos endpoints forem adicionados ou alterações forem feitas.
 
+## 20 de maio de 2025
+
+### ✨ Novidades
+
+- Adicionado o endpoint [DELETE /messages/:uuid](/api/reference/messages_api/delete_message) para eliminar um mensagem por UUID ou ID externo.
+
 ## 17 de fevereiro de 2025
 
 ### ✨ Novidades

--- a/src/snippets/csharp/messages_api/_delete_message.mdx
+++ b/src/snippets/csharp/messages_api/_delete_message.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Delete, "https://api.callbell.eu/v1/messages");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("{\n    \"uuid\": \"1da07a20eb0d46728f89d234a727607a\"\n  }");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/curl/messages_api/_delete_message.mdx
+++ b/src/snippets/curl/messages_api/_delete_message.mdx
@@ -1,0 +1,8 @@
+```bash
+curl -X DELETE "https://api.callbell.eu/v1/messages" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "uuid": "1da07a20eb0d46728f89d234a727607a"
+  }'
+```

--- a/src/snippets/go/messages_api/_delete_message.mdx
+++ b/src/snippets/go/messages_api/_delete_message.mdx
@@ -1,0 +1,35 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	client := &http.Client{}
+	var data = strings.NewReader(`{
+    "uuid": "1da07a20eb0d46728f89d234a727607a"
+  }`)
+	req, err := http.NewRequest("DELETE", "https://api.callbell.eu/v1/messages", data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/java/messages_api/_delete_message.mdx
+++ b/src/snippets/java/messages_api/_delete_message.mdx
@@ -1,0 +1,35 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/messages");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("DELETE");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		httpConn.setDoOutput(true);
+		OutputStreamWriter writer = new OutputStreamWriter(httpConn.getOutputStream());
+		writer.write("{\n    \"uuid\": \"1da07a20eb0d46728f89d234a727607a\"\n  }");
+		writer.flush();
+		writer.close();
+		httpConn.getOutputStream().close();
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/node/messages_api/_delete_message.mdx
+++ b/src/snippets/node/messages_api/_delete_message.mdx
@@ -1,0 +1,15 @@
+```js
+import axios from 'axios';
+
+const response = await axios.delete('https://api.callbell.eu/v1/messages', {
+  headers: {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json'
+  },
+  // data: '{\n    "uuid": "1da07a20eb0d46728f89d234a727607a"\n  }',
+  data: {
+    'uuid': '1da07a20eb0d46728f89d234a727607a'
+  }
+});
+
+```

--- a/src/snippets/php/messages_api/_delete_message.mdx
+++ b/src/snippets/php/messages_api/_delete_message.mdx
@@ -1,0 +1,17 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/messages');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "{\n    \"uuid\": \"1da07a20eb0d46728f89d234a727607a\"\n  }");
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/python/messages_api/_delete_message.mdx
+++ b/src/snippets/python/messages_api/_delete_message.mdx
@@ -1,0 +1,20 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+json_data = {
+    'uuid': '1da07a20eb0d46728f89d234a727607a',
+}
+
+response = requests.delete('https://api.callbell.eu/v1/messages', headers=headers, json=json_data)
+
+# Note: json_data will not be serialized by requests
+# exactly as it was in the original request.
+#data = '{\n    "uuid": "1da07a20eb0d46728f89d234a727607a"\n  }'
+#response = requests.delete('https://api.callbell.eu/v1/messages', headers=headers, data=data)
+
+```

--- a/src/snippets/ruby/messages_api/_delete_message.mdx
+++ b/src/snippets/ruby/messages_api/_delete_message.mdx
@@ -1,0 +1,23 @@
+```ruby
+require 'net/http'
+require 'json'
+
+uri = URI('https://api.callbell.eu/v1/messages')
+req = Net::HTTP::Delete.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+# The object won't be serialized exactly like this
+# req.body = "{\n    \"uuid\": \"1da07a20eb0d46728f89d234a727607a\"\n  }"
+req.body = {
+  'uuid' => '1da07a20eb0d46728f89d234a727607a'
+}.to_json
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/rust/messages_api/_delete_message.mdx
+++ b/src/snippets/rust/messages_api/_delete_message.mdx
@@ -1,0 +1,29 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.delete("https://api.callbell.eu/v1/messages")
+        .headers(headers)
+        .body(r#"
+{
+    "uuid": "1da07a20eb0d46728f89d234a727607a"
+  }
+"#
+        )
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
## PR Description

This PR adds a documentation section for the DELETE /messages endpoint introduced in https://github.com/callbellchat/callbell/pull/3670