### PR TITLE
docs: add Plan API endpoint documentation

### DIFF
--- a/docs/api/reference/plan_api/_category_.json
+++ b/docs/api/reference/plan_api/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Plan API",
+  "position": 13
+}

--- a/docs/api/reference/plan_api/get_plan.md
+++ b/docs/api/reference/plan_api/get_plan.md
@@ -1,0 +1,44 @@
+---
+title: GET /plan
+sidebar_position: 2
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /plan
+
+Get the current plan details for your account, including plan metadata, active user count, and a breakdown of teams with their members.
+
+### Example Request
+
+<RequestTabs endpoint='plan_api' request="get_plan"/>
+
+### Response
+
+| Parameter         | Type                                       | Description                                              |
+| :---------------- | :----------------------------------------- | :------------------------------------------------------- |
+| `plan`            | string                                     | The name of the current plan                             |
+| `includedChannels`| integer                                    | The number of channels included in the plan              |
+| `licenses`        | integer                                    | The number of team member seats included in the plan     |
+| `activeUsers`     | integer                                    | The number of active (confirmed) users in the account    |
+| `teams`           | [Team[]](/api/reference/object_types/team)  | A list of teams in the account                           |
+
+### Example Response
+
+```json title=response.json
+{
+  "plan": "business_plus",
+  "includedChannels": 3,
+  "licenses": 5,
+  "activeUsers": 2,
+  "teams": [
+    {
+      "uuid": "ad42a09715814e6483b1c5debd6a2dbc",
+      "name": "Support",
+      "createdAt": "2020-11-13T21:08:53Z",
+      "default": false,
+      "members": 2
+    }
+  ]
+}
+```

--- a/docs/api/reference/plan_api/introduction.md
+++ b/docs/api/reference/plan_api/introduction.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 1
+---
+
+# Introduction
+
+Plan API allows you to programmatically retrieve your account's current plan details, including plan metadata, active user count, and a breakdown of teams with their members.

--- a/docs/api/reference/teams_api/_category_.json
+++ b/docs/api/reference/teams_api/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Teams API",
-  "position": 13
+  "position": 14
 }
 

--- a/docs/api/reference/template_messages_api/_category_.json
+++ b/docs/api/reference/template_messages_api/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Templates API",
-  "position": 14
+  "position": 15
 }

--- a/docs/api/reference/users_api/_category_.json
+++ b/docs/api/reference/users_api/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Users API",
-  "position": 15
+  "position": 16
 }

--- a/docs/api/reference/webhooks_api/_category_.json
+++ b/docs/api/reference/webhooks_api/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Webhooks API",
-  "position": 16
+  "position": 17
 }

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## February 10, 2026
+
+### ✨ What's new
+
+- Added [GET /plan](/api/reference/plan_api/get_plan) endpoint to retrieve the current account's plan details, including active users and team breakdown.
+
 ## February 6, 2026
 
 ### 🛠️ Changes

--- a/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Una lista de todos los cambios y mejoras que se han introducido en nuestra API. Úsala para verificar cuando se agregan nuevos puntos finales o se realizan cambios.
 
+## 10 de febrero de 2026
+
+### ✨ Novedades
+
+- Se agregó el endpoint [GET /plan](/api/reference/plan_api/get_plan) para obtener los detalles del plan de la cuenta actual, incluyendo los usuarios activos y el desglose de equipos.
+
 ## 6 de febrero de 2026
 
 ### 🛠️ Cambios

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Une liste de tous les changements et améliorations qui ont été introduits dans notre API. Utilisez-la pour vérifier si de nouveaux points finaux sont ajoutés ou si des modifications sont apportées.
 
+## 10 février 2026
+
+### ✨ Nouveautés
+
+- Ajout du point de terminaison [GET /plan](/api/reference/plan_api/get_plan) pour récupérer les détails du plan du compte actuel, y compris les utilisateurs actifs et la répartition des équipes.
+
 ## 6 février 2026
 
 ### 🛠️ Changements

--- a/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Un elenco di tutte le modifiche e miglioramenti introdotti nella nostra API. Utilizzalo per controllare se sono stati aggiunti nuovi endpoint o apportate modifiche.
 
+## 10 febbraio 2026
+
+### ✨ Novità
+
+- Aggiunto l'endpoint [GET /plan](/api/reference/plan_api/get_plan) per recuperare i dettagli del piano dell'account corrente, inclusi gli utenti attivi e la suddivisione dei team.
+
 ## 6 febbraio 2026
 
 ### 🛠️ Modifiche

--- a/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 Uma lista de todas as alterações e melhorias que foram introduzidas em nossa API. Use para verificar sempre que novos endpoints forem adicionados ou alterações forem feitas.
 
+## 10 de fevereiro de 2026
+
+### ✨ Novidades
+
+- Adicionado o endpoint [GET /plan](/api/reference/plan_api/get_plan) para obter os detalhes do plano da conta atual, incluindo os usuários ativos e a divisão de equipes.
+
 ## 6 de fevereiro de 2026
 
 ### 🛠️ Alterações

--- a/src/snippets/csharp/plan_api/_get_plan.mdx
+++ b/src/snippets/csharp/plan_api/_get_plan.mdx
@@ -1,0 +1,17 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/plan");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+```

--- a/src/snippets/curl/plan_api/_get_plan.mdx
+++ b/src/snippets/curl/plan_api/_get_plan.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/plan" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/go/plan_api/_get_plan.mdx
+++ b/src/snippets/go/plan_api/_get_plan.mdx
@@ -1,0 +1,30 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/plan", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+```

--- a/src/snippets/java/plan_api/_get_plan.mdx
+++ b/src/snippets/java/plan_api/_get_plan.mdx
@@ -1,0 +1,26 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/plan");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+```

--- a/src/snippets/node/plan_api/_get_plan.mdx
+++ b/src/snippets/node/plan_api/_get_plan.mdx
@@ -1,0 +1,11 @@
+```js
+import axios from 'axios';
+
+const response = await axios.get('https://api.callbell.eu/v1/plan', {
+  headers: {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json'
+  }
+});
+
+```

--- a/src/snippets/php/plan_api/_get_plan.mdx
+++ b/src/snippets/php/plan_api/_get_plan.mdx
@@ -1,0 +1,15 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/plan');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+```

--- a/src/snippets/python/plan_api/_get_plan.mdx
+++ b/src/snippets/python/plan_api/_get_plan.mdx
@@ -1,0 +1,10 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/plan', headers=headers)
+```

--- a/src/snippets/ruby/plan_api/_get_plan.mdx
+++ b/src/snippets/ruby/plan_api/_get_plan.mdx
@@ -1,0 +1,15 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/plan')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+```

--- a/src/snippets/rust/plan_api/_get_plan.mdx
+++ b/src/snippets/rust/plan_api/_get_plan.mdx
@@ -1,0 +1,22 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/plan")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+```


### PR DESCRIPTION
## PR Description

Adds public-facing documentation for the new **GET /v1/plan** API endpoint:

- **Introduction page** — brief overview of the Plan API
- **Endpoint reference** (`get_plan.md`) — response parameter table with types and descriptions, example JSON response
- **Code snippets** — request examples in all 9 supported languages (cURL, Node.js, Ruby, Go, PHP, Python, C#, Java, Rust)
- **Release notes** — changelog entry added in all 5 locales (EN, ES, FR, IT, PT)
- **Sidebar reordering** — Plan API inserted at position 13; Teams, Templates, Users, Webhooks bumped by 1

## Preview

_Documentation-only change. The API endpoint itself is implemented in [callbell#4680](https://github.com/callbellchat/callbell/pull/4680)._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new markdown/snippets and sidebar ordering) with no runtime or API behavior impact.
> 
> **Overview**
> Adds a new **Plan API** documentation section with an introduction and a `GET /plan` reference page, including response field descriptions and an example payload.
> 
> Includes new request snippets for `GET /v1/plan` across all supported languages (e.g., cURL/Node/Ruby/Go/PHP/Python/C#/Java/Rust), and updates API release notes (EN + ES/FR/IT/PT) to announce the endpoint.
> 
> Adjusts sidebar ordering by inserting Plan API at position 13 and shifting `Teams`/`Templates`/`Users`/`Webhooks` categories down by one.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9c146b9dae073b8eb807f2eaba67a69e9510aab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->