### PR TITLE
docs: add typing indicator bot action documentation

### DIFF
--- a/docs/bot/editor/actions/interaction/typing_indicator.md
+++ b/docs/bot/editor/actions/interaction/typing_indicator.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 1
+---
+
+# Typing Indicator
+
+The **Typing Indicator** action sends typing dots ("...") to the customer on WhatsApp, simulating a more natural conversation. The dots are automatically dismissed when the next message is sent or after 25 seconds.
+
+This action is only available for **WhatsApp Cloud API** channels.
+
+## How to use it
+
+Place this action right after receiving a user message (either at the start of the flow or after a "Wait for user's answer" action). It works best before a heavy processing step like an **AI Agent**, **OpenAI**, or **Webhook** action, where the user would otherwise see no activity while the bot processes their request.
+
+**Example flow:**
+
+1. User sends a message
+2. **Typing indicator** (dots appear)
+3. AI Agent / Webhook processes the request
+4. Send message (dots disappear, response arrives)
+
+:::tip
+The typing indicator also marks the user's message as "read" (blue ticks) on WhatsApp.
+:::
+
+:::info
+This action is available exclusively for WhatsApp Cloud API channels and will not appear in the action list for other channel types.
+:::


### PR DESCRIPTION
## PR Description

Adds documentation for the new **Typing Indicator** bot action, which sends typing dots ("...") to WhatsApp Cloud API customers to simulate a more natural conversation.

The doc covers:
- What the action does (shows dots, auto-dismissed after 25s or on next message)
- How to use it (placement guidance with example flow)
- Side effect: also marks user messages as read (blue ticks)
- Channel availability (WhatsApp Cloud API only)

## Preview

_Add a preview (e.g. screenshot, gif, video, etc.) of the changes you made._

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)