### PR TITLE
enh: Closing reason in conversation_closed webhook event

### DIFF
--- a/docs/api/reference/webhooks/conversation_events/conversation_closed.md
+++ b/docs/api/reference/webhooks/conversation_events/conversation_closed.md
@@ -32,8 +32,10 @@ See [Conversation Object](/api/reference/object_types/conversation)
       "createdAt": "2022-10-12T15:57:16Z",
       "phoneNumber": "331122334455"
     },
+    "closingReason": "issue_resolved",
     "createdAt": "2023-11-20T17:14:22Z",
     "closedAt": "2023-11-20T17:14:22Z"
   }
 }
 ```
+

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## February 19, 2026
+
+### ✨ What's new
+
+- Added closing reason field to `conversation_closed` webhook event.
+
 ## February 10, 2026
 
 ### ✨ What's new


### PR DESCRIPTION
## PR Description
This PR updates `conversation_closed` event according to the change made in this PR https://github.com/callbellchat/callbell/pull/4715, by adding `closing_reason`.

## Preview
<img width="1168" height="867" alt="image" src="https://github.com/user-attachments/assets/5cef822b-028d-4ef9-8e09-50e33156de16" />
