### PR TITLE
[FEAT] Add custom field validation and metadata to Public API

### DIFF
--- a/docs/api/reference/contacts_api/get_contact.md
+++ b/docs/api/reference/contacts_api/get_contact.md
@@ -15,6 +15,12 @@ Get a specific contact given a `uuid`.
 | :-------- | :----- | :---------------------- |
 | `uuid`    | string | The uuid of the contact |
 
+### Optional Parameters
+
+| Parameter             | Type    | Description                                                                                                   |
+| :-------------------- | :------ | :------------------------------------------------------------------------------------------------------------ |
+| `include_field_types` | boolean | When `true`, the response includes `customFieldsMetadata` with value, type and options for each custom field. |
+
 ### Example Request
 
 <RequestTabs endpoint='contacts_api' request="get_contact"/>
@@ -45,6 +51,29 @@ Get a specific contact given a `uuid`.
         "Address": "Oxford Street 123",
         "Billing Address": "Oxford Street 123",
         "VAT": "ABC123DCE456"
+      }
+    }
+  ]
+}
+```
+
+### Example Response (with `include_field_types=true`)
+
+```json title=response.json
+{
+  "contact": [
+    {
+      "uuid": "414a6d692bd645ed803f2e7ce360d4c8",
+      "name": "John Doe",
+      "customFields": {
+        "Address": "Oxford Street 123",
+        "Birth Date": "1990-05-15",
+        "Features": "[\"Dark Mode\", \"Notifications\"]"
+      },
+      "customFieldsMetadata": {
+        "Address": { "value": "Oxford Street 123", "type": "text" },
+        "Birth Date": { "value": "1990-05-15", "type": "date" },
+        "Features": { "value": ["Dark Mode", "Notifications"], "type": "checkbox", "options": ["Dark Mode", "Notifications", "Analytics"] }
       }
     }
   ]

--- a/docs/api/reference/contacts_api/get_contacts.md
+++ b/docs/api/reference/contacts_api/get_contacts.md
@@ -16,7 +16,8 @@ List all contacts belonging to the account. A filter can be specified in order t
 | `page`      | Integer  | The page of contacts. If not specified it will default to page 1.                  |
 | `source`    | Source   | The integration type (e.g. `whatsapp`)                                             |
 | `tags`      | string[] | The matching tags, comma-separated (e.g. `sales,lead`). Tags are _case-insentive_. |
-| `team_uuid` | string   | The uuid of the team.                                                              |
+| `team_uuid`           | string   | The uuid of the team.                                                              |
+| `include_field_types` | boolean  | When `true`, the response includes `customFieldsMetadata` with value, type and options for each custom field. |
 
 ### Example Request
 
@@ -70,6 +71,29 @@ List all contacts belonging to the account. A filter can be specified in order t
       ],
       "customFields":{
         "Stripe link": "https://stripe.com/contacts/cus124124153"
+      }
+    }
+  ]
+}
+```
+
+### Example Response (with `include_field_types=true`)
+
+```json title=response.json
+{
+  "contacts": [
+    {
+      "uuid": "414a6d692bd645ed803f2e7ce360d4c8",
+      "name": "John Doe",
+      "customFields": {
+        "Address": "Oxford Street 123",
+        "Join Date": "2024-01-15",
+        "Preferences": "[\"Newsletter\", \"Promotions\"]"
+      },
+      "customFieldsMetadata": {
+        "Address": { "value": "Oxford Street 123", "type": "text" },
+        "Join Date": { "value": "2024-01-15", "type": "date" },
+        "Preferences": { "value": ["Newsletter", "Promotions"], "type": "checkbox", "options": ["Newsletter", "Promotions", "Updates"] }
       }
     }
   ]

--- a/docs/api/reference/contacts_api/patch_contacts.md
+++ b/docs/api/reference/contacts_api/patch_contacts.md
@@ -20,7 +20,7 @@ Updates an existing contact.
 | Parameter       | Type     | Description                                                                      |
 | :-------------- | :------- | :------------------------------------------------------------------------------- |
 | `tags`          | string[] | A list of comma-separated values (e.g `['Call back', 'Interested']`)             |
-| `custom_fields` | string{} | An object with the custom fields (e.g. `{'Billing Address': 'Main Street 1}`)    |
+| `custom_fields` | String{} \| Object | An object with the custom fields. Values can be strings or arrays depending on the field type (see below). |
 | `name`          | string   | The name of the contact                                                          |
 | `assigned_user` | String   | Email of the the collaborator that you want to assign to a contact               |
 | `unassign_user` | Boolean  | `true` is you want to remove the assigned collaborator from a contact            |
@@ -36,7 +36,34 @@ If you have a bot enabled, the default status is `bot_start`.
 :::caution
 Ensure that `custom_fields` and `tags` already exist in your account before passing them. Visit [tags](https://dash.callbell.eu/settings/tags) and [custom_fields](https://dash.callbell.eu/settings/custom_fields) in your settings for more information.
 
+For dropdown and checkbox custom fields, you must also configure the available options when creating the field. These options are displayed in the dashboard and enforced during validation.
+
 Similarly, for `assigned_user` and `team_uuid`, use a valid email address associated with a user in your account or reference an existing team.
+:::
+
+:::info
+Custom field values are validated based on their field type. Invalid values will return a validation error. Here are the expected formats per type:
+
+| Type       | Value format | Example                                            |
+| :--------- | :----------- | :------------------------------------------------- |
+| `text`     | string       | `"Main Street 1"`                                  |
+| `email`    | string       | `"user@example.com"`                               |
+| `number`   | string       | `"42"`                                             |
+| `date`     | string       | `"2026-03-03"`                                     |
+| `dropdown` | string       | `"Active"` (must match one of the available options)|
+| `checkbox` | string[]     | `["Dark Mode", "Notifications"]` (must match available options) |
+
+Example:
+```json
+{
+  "custom_fields": {
+    "Billing Address": "Main Street 1",
+    "Work Email": "user@example.com",
+    "Status": "Active",
+    "Features": ["Dark Mode", "Notifications"]
+  }
+}
+```
 :::
 
 ### Example Request

--- a/docs/api/reference/contacts_api/post_contacts.md
+++ b/docs/api/reference/contacts_api/post_contacts.md
@@ -22,7 +22,7 @@ Creates a new contact.
 | Parameter       | Type     | Description                                                                                             |
 | :-------------- | :------- | :------------------------------------------------------------------------------------------------------ |
 | `tags`          | String[] | A list of comma-separated values (e.g `['Call back', 'Interested']`)                                    |
-| `custom_fields` | String{} | An object with the custom fields (e.g. `{'Billing Address': 'Main Street 1'}`)                          |
+| `custom_fields` | String{} \| Object | An object with the custom fields. Values can be strings or arrays depending on the field type (see below). |
 | `assigned_user` | String   | Email of the user that you want to assign to a contact                                                  |
 | `team_uuid`     | String   | UUID of the team that you want to assign to a contact                                                   |
 | `channel_uuid`  | String   | The message will be sent from this channel (when omitted, it will use the default main channel)         |
@@ -37,7 +37,34 @@ If you have a bot enabled, the default status is `bot_start` meaning that the bo
 :::caution
 When passing `custom_fields` or `tags` make sure that they exist in your account. See [tags](https://dash.callbell.eu/settings/tags) and [custom_fields](https://dash.callbell.eu/settings/custom_fields) in your settings.
 
+For dropdown and checkbox custom fields, you must also configure the available options when creating the field. These options are displayed in the dashboard and enforced during validation.
+
 Same applies for `assigned_user` and `team_uuid`: either needs to exists in your account.
+:::
+
+:::info
+Custom field values are validated based on their field type. Invalid values will return a validation error. Here are the expected formats per type:
+
+| Type       | Value format | Example                                            |
+| :--------- | :----------- | :------------------------------------------------- |
+| `text`     | string       | `"Main Street 1"`                                  |
+| `email`    | string       | `"user@example.com"`                               |
+| `number`   | string       | `"42"`                                             |
+| `date`     | string       | `"2026-03-03"`                                     |
+| `dropdown` | string       | `"Active"` (must match one of the available options)|
+| `checkbox` | string[]     | `["Dark Mode", "Notifications"]` (must match available options) |
+
+Example:
+```json
+{
+  "custom_fields": {
+    "Billing Address": "Main Street 1",
+    "Work Email": "user@example.com",
+    "Status": "Active",
+    "Features": ["Dark Mode", "Notifications"]
+  }
+}
+```
 :::
 
 ### Example Request

--- a/docs/api/reference/object_types/contact.md
+++ b/docs/api/reference/object_types/contact.md
@@ -20,6 +20,7 @@ sidebar_position: 1
 | `conversationHref` | string                  | Link to dashboard conversation                          |
 | `tags`             | string                  | List of associated tags                                 |
 | `assignedUser`     | string                  | Email of the user that the contact is assigned to       |
-| `customFields`     | string                  | List of associated custom fields                        |
-| `team`             | [Team](./team.md)       | Team inbox currently associated to the contact          |
-| `channel`          | [Channel](./channel.md) | Channel currently associated to the contact             |
+| `customFields`         | string                  | List of associated custom fields                                                                    |
+| `customFieldsMetadata` | object                  | Custom fields with value, type and options. Only returned when `include_field_types=true` is passed. |
+| `team`                 | [Team](./team.md)       | Team inbox currently associated to the contact                                                      |
+| `channel`              | [Channel](./channel.md) | Channel currently associated to the contact                                                         |

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,13 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## March 3, 2026
+
+### ✨ What's new
+
+- Added `include_field_types` query parameter to [GET /contacts](/api/reference/contacts_api/get_contacts) and [GET /contacts/:uuid](/api/reference/contacts_api/get_contact). When set to `true`, the response includes a `customFieldsMetadata` attribute with the typed value, field type, and available options (for dropdown and checkbox fields) for each custom field.
+- Custom field values are now validated based on their field type when [creating](/api/reference/contacts_api/post_contacts) or [updating](/api/reference/contacts_api/patch_contacts) contacts. Supported types: `text`, `email`, `number`, `date`, `dropdown`, `checkbox`.
+
 ## February 19, 2026
 
 ### ✨ What's new


### PR DESCRIPTION

### Summary
Updated API documentation to document two new custom field features:

- Custom field value validation: All field types (text, email, number, date, dropdown, checkbox) are now validated on create/update
- Field type metadata: New include_field_types=true query parameter returns customFieldsMetadata with typed values and available options

### Changes
- Contact object: Added customFieldsMetadata field description
- GET /contacts & GET /contacts/:uuid: Added include_field_types optional parameter and example responses showing text, date, checkbox types
- POST & PATCH /contacts: Updated custom_fields param type to String{} | Object, documented validation rules with type table, clarified checkbox and dropdown field setup requirements
- Release notes: Added March 4, 2026 entry documenting both features
### API Examples

- **Text field**: "Address": "Oxford Street 123"
- **Date field**: "Birth Date": "1990-05-15"
- **Checkbox field**: "Features": ["Dark Mode", "Notifications"]
- **Response with metadata**: Returns { "value": "...", "type": "...", "options": [...] } when ?include_field_types=true
