### PR TITLE
[DOCS] Add GET /contacts/bsuid/:bsuid endpoint (CAL-1143)

### DIFF
--- a/docs/api/reference/contacts_api/get_contact_by_bsuid.md
+++ b/docs/api/reference/contacts_api/get_contact_by_bsuid.md
@@ -1,0 +1,49 @@
+---
+title: GET /contacts/bsuid/:bsuid
+sidebar_position: 5
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/bsuid/:bsuid
+
+Get a specific contact given a `bsuid` (Business Suite User ID). This is useful for looking up contacts that may not have a phone number associated (e.g. WhatsApp username-privacy users).
+
+### Required Parameters
+
+| Parameter | Type   | Description                              |
+| :-------- | :----- | :--------------------------------------- |
+| `bsuid`   | string | The Business Suite User ID of the contact |
+
+### Example Request
+
+<RequestTabs endpoint='contacts_api' request="get_contact_by_bsuid"/>
+
+### Response
+
+| Parameter | Type                                           | Description                          |
+| :-------- | :--------------------------------------------- | :----------------------------------- |
+| `contact` | [Contact](/api/reference/object_types/contact) | The object representing the contact. |
+
+### Example Response
+
+```json title=response.json
+{
+  "contact": {
+    "uuid": "414a6d692bd645ed803f2e7ce360d4c8",
+    "name": "John Doe",
+    "phoneNumber": "+123 456 789",
+    "avatarUrl": null,
+    "createdAt": "2020-11-13T21:08:53Z",
+    "source": "whatsapp",
+    "href": "https://dash.callbell.eu/contacts/414a6d692bd645ed803f2e7ce360d4c8",
+    "conversationHref": "https://dash.callbell.eu/chat/f3670b13446b412796238b1cd78899f9",
+    "tags": ["sales", "lead"],
+    "assignedUser": null,
+    "customFields": {
+      "Address": "Oxford Street 123"
+    },
+    "bsuid": "bsuid_abc123"
+  }
+}
+```

--- a/i18n/es/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_by_bsuid.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_by_bsuid.md
@@ -1,0 +1,49 @@
+---
+title: GET /contacts/bsuid/:bsuid
+sidebar_position: 5
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/bsuid/:bsuid
+
+Obtiene un contacto específico a partir de un `bsuid` (Business Suite User ID). Esto es útil para buscar contactos que pueden no tener un número de teléfono asociado (p. ej., usuarios con privacidad de nombre de usuario en WhatsApp).
+
+### Parámetros obligatorios
+
+| Parámetro | Tipo   | Descripción                                       |
+| :-------- | :----- | :------------------------------------------------ |
+| `bsuid`   | string | El ID de usuario de Business Suite del contacto. |
+
+### Ejemplo de solicitud
+
+<RequestTabs endpoint='contacts_api' request="get_contact_by_bsuid"/>
+
+### Respuesta
+
+| Parámetro | Tipo                                            | Descripción                         |
+| :-------- | :---------------------------------------------- | :---------------------------------- |
+| `contact` | [Contacto](/api/reference/object_types/contact) | El objeto que representa el contacto. |
+
+### Ejemplo de respuesta
+
+```json title=response.json
+{
+  "contact": {
+    "uuid": "414a6d692bd645ed803f2e7ce360d4c8",
+    "name": "John Doe",
+    "phoneNumber": "+123 456 789",
+    "avatarUrl": null,
+    "createdAt": "2020-11-13T21:08:53Z",
+    "source": "whatsapp",
+    "href": "https://dash.callbell.eu/contacts/414a6d692bd645ed803f2e7ce360d4c8",
+    "conversationHref": "https://dash.callbell.eu/chat/f3670b13446b412796238b1cd78899f9",
+    "tags": ["sales", "lead"],
+    "assignedUser": null,
+    "customFields": {
+      "Address": "Oxford Street 123"
+    },
+    "bsuid": "bsuid_abc123"
+  }
+}
+```

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_by_bsuid.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_by_bsuid.md
@@ -1,0 +1,49 @@
+---
+title: GET /contacts/bsuid/:bsuid
+sidebar_position: 5
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/bsuid/:bsuid
+
+Récupérez un contact spécifique à partir d’un `bsuid` (Business Suite User ID). Utile pour rechercher des contacts qui n’ont peut-être pas de numéro de téléphone associé (par exemple, des utilisateurs WhatsApp dont le nom d’utilisateur est privé).
+
+### Paramètres requis
+
+| Paramètre | Type   | Description                             |
+| :-------- | :----- | :-------------------------------------- |
+| `bsuid`   | string | L’ID utilisateur Business Suite du contact |
+
+### Exemple de requête
+
+<RequestTabs endpoint='contacts_api' request="get_contact_by_bsuid"/>
+
+### Réponse
+
+| Paramètre | Type                                           | Description                       |
+| :-------- | :--------------------------------------------- | :-------------------------------- |
+| `contact` | [Contact](/api/reference/object_types/contact) | L’objet représentant le contact. |
+
+### Exemple de réponse
+
+```json title=response.json
+{
+  "contact": {
+    "uuid": "414a6d692bd645ed803f2e7ce360d4c8",
+    "name": "John Doe",
+    "phoneNumber": "+123 456 789",
+    "avatarUrl": null,
+    "createdAt": "2020-11-13T21:08:53Z",
+    "source": "whatsapp",
+    "href": "https://dash.callbell.eu/contacts/414a6d692bd645ed803f2e7ce360d4c8",
+    "conversationHref": "https://dash.callbell.eu/chat/f3670b13446b412796238b1cd78899f9",
+    "tags": ["sales", "lead"],
+    "assignedUser": null,
+    "customFields": {
+      "Address": "Oxford Street 123"
+    },
+    "bsuid": "bsuid_abc123"
+  }
+}
+```

--- a/i18n/it/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_by_bsuid.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_by_bsuid.md
@@ -1,0 +1,49 @@
+---
+title: GET /contacts/bsuid/:bsuid
+sidebar_position: 5
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/bsuid/:bsuid
+
+Recupera un contatto specifico dato un `bsuid` (Business Suite User ID). È utile per cercare contatti che potrebbero non avere un numero di telefono associato (ad es. utenti WhatsApp con privacy sul nome utente).
+
+### Parametri richiesti
+
+| Parametro | Tipo   | Descrizione                              |
+| :-------- | :----- | :---------------------------------------- |
+| `bsuid`   | string | L'ID utente di Business Suite del contatto |
+
+### Esempio di richiesta
+
+<RequestTabs endpoint='contacts_api' request="get_contact_by_bsuid"/>
+
+### Risposta
+
+| Parametro | Tipo                                           | Descrizione                          |
+| :-------- | :--------------------------------------------- | :----------------------------------- |
+| `contact` | [Contatto](/api/reference/object_types/contact) | L'oggetto che rappresenta il contatto. |
+
+### Esempio di risposta
+
+```json title=response.json
+{
+  "contact": {
+    "uuid": "414a6d692bd645ed803f2e7ce360d4c8",
+    "name": "John Doe",
+    "phoneNumber": "+123 456 789",
+    "avatarUrl": null,
+    "createdAt": "2020-11-13T21:08:53Z",
+    "source": "whatsapp",
+    "href": "https://dash.callbell.eu/contacts/414a6d692bd645ed803f2e7ce360d4c8",
+    "conversationHref": "https://dash.callbell.eu/chat/f3670b13446b412796238b1cd78899f9",
+    "tags": ["sales", "lead"],
+    "assignedUser": null,
+    "customFields": {
+      "Address": "Oxford Street 123"
+    },
+    "bsuid": "bsuid_abc123"
+  }
+}
+```

--- a/i18n/pt/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_by_bsuid.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/api/reference/contacts_api/get_contact_by_bsuid.md
@@ -1,0 +1,49 @@
+---
+title: GET /contacts/bsuid/:bsuid
+sidebar_position: 5
+---
+
+import RequestTabs from "@site/src/components/Requests/RequestTabs"
+
+# GET /contacts/bsuid/:bsuid
+
+Obtenha um contato específico dado um `bsuid` (ID de usuário do Business Suite). Isso é útil para buscar contatos que podem não ter um número de telefone associado (por exemplo, usuários do WhatsApp com privacidade de nome de usuário).
+
+### Parâmetros obrigatórios
+
+| Parâmetro | Tipo   | Descrição                                    |
+| :-------- | :----- | :------------------------------------------- |
+| `bsuid`   | string | O ID de usuário do Business Suite do contato |
+
+### Exemplo de requisição
+
+<RequestTabs endpoint='contacts_api' request="get_contact_by_bsuid"/>
+
+### Resposta
+
+| Parâmetro | Tipo                                           | Descrição                          |
+| :-------- | :--------------------------------------------- | :--------------------------------- |
+| `contact` | [Contato](/api/reference/object_types/contact) | O objeto que representa o contato. |
+
+### Exemplo de resposta
+
+```json title=response.json
+{
+  "contact": {
+    "uuid": "414a6d692bd645ed803f2e7ce360d4c8",
+    "name": "John Doe",
+    "phoneNumber": "+123 456 789",
+    "avatarUrl": null,
+    "createdAt": "2020-11-13T21:08:53Z",
+    "source": "whatsapp",
+    "href": "https://dash.callbell.eu/contacts/414a6d692bd645ed803f2e7ce360d4c8",
+    "conversationHref": "https://dash.callbell.eu/chat/f3670b13446b412796238b1cd78899f9",
+    "tags": ["sales", "lead"],
+    "assignedUser": null,
+    "customFields": {
+      "Address": "Oxford Street 123"
+    },
+    "bsuid": "bsuid_abc123"
+  }
+}
+```

--- a/src/snippets/csharp/contacts_api/_get_contact_by_bsuid.mdx
+++ b/src/snippets/csharp/contacts_api/_get_contact_by_bsuid.mdx
@@ -1,0 +1,18 @@
+```csharp
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+HttpClient client = new HttpClient();
+
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://api.callbell.eu/v1/contacts/bsuid/bsuid_abc123");
+
+request.Headers.Add("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+
+request.Content = new StringContent("");
+request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+HttpResponseMessage response = await client.SendAsync(request);
+response.EnsureSuccessStatusCode();
+string responseBody = await response.Content.ReadAsStringAsync();
+
+```

--- a/src/snippets/curl/contacts_api/_get_contact_by_bsuid.mdx
+++ b/src/snippets/curl/contacts_api/_get_contact_by_bsuid.mdx
@@ -1,0 +1,5 @@
+```bash
+curl -X GET "https://api.callbell.eu/v1/contacts/bsuid/bsuid_abc123" \
+  -H "Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM" \
+  -H "Content-Type: application/json"
+```

--- a/src/snippets/go/contacts_api/_get_contact_by_bsuid.mdx
+++ b/src/snippets/go/contacts_api/_get_contact_by_bsuid.mdx
@@ -1,0 +1,31 @@
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+func main() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.callbell.eu/v1/contacts/bsuid/bsuid_abc123", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", bodyText)
+}
+
+```

--- a/src/snippets/java/contacts_api/_get_contact_by_bsuid.mdx
+++ b/src/snippets/java/contacts_api/_get_contact_by_bsuid.mdx
@@ -1,0 +1,27 @@
+```java
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+class Main {
+
+	public static void main(String[] args) throws IOException {
+		URL url = new URL("https://api.callbell.eu/v1/contacts/bsuid/bsuid_abc123");
+		HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+		httpConn.setRequestMethod("GET");
+
+		httpConn.setRequestProperty("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM");
+		httpConn.setRequestProperty("Content-Type", "application/json");
+
+		InputStream responseStream = httpConn.getResponseCode() / 100 == 2
+				? httpConn.getInputStream()
+				: httpConn.getErrorStream();
+		Scanner s = new Scanner(responseStream).useDelimiter("\\A");
+		String response = s.hasNext() ? s.next() : "";
+		System.out.println(response);
+	}
+}
+
+```

--- a/src/snippets/node/contacts_api/_get_contact_by_bsuid.mdx
+++ b/src/snippets/node/contacts_api/_get_contact_by_bsuid.mdx
@@ -1,0 +1,11 @@
+```js
+import axios from 'axios';
+
+const response = await axios.get('https://api.callbell.eu/v1/contacts/bsuid/bsuid_abc123', {
+  headers: {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json'
+  }
+});
+
+```

--- a/src/snippets/php/contacts_api/_get_contact_by_bsuid.mdx
+++ b/src/snippets/php/contacts_api/_get_contact_by_bsuid.mdx
@@ -1,0 +1,16 @@
+```php
+<?php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.callbell.eu/v1/contacts/bsuid/bsuid_abc123');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type: application/json',
+]);
+
+$response = curl_exec($ch);
+
+curl_close($ch);
+
+```

--- a/src/snippets/python/contacts_api/_get_contact_by_bsuid.mdx
+++ b/src/snippets/python/contacts_api/_get_contact_by_bsuid.mdx
@@ -1,0 +1,11 @@
+```python
+import requests
+
+headers = {
+    'Authorization': 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM',
+    'Content-Type': 'application/json',
+}
+
+response = requests.get('https://api.callbell.eu/v1/contacts/bsuid/bsuid_abc123', headers=headers)
+
+```

--- a/src/snippets/ruby/contacts_api/_get_contact_by_bsuid.mdx
+++ b/src/snippets/ruby/contacts_api/_get_contact_by_bsuid.mdx
@@ -1,0 +1,16 @@
+```ruby
+require 'net/http'
+
+uri = URI('https://api.callbell.eu/v1/contacts/bsuid/bsuid_abc123')
+req = Net::HTTP::Get.new(uri)
+req.content_type = 'application/json'
+req['Authorization'] = 'Bearer test_gshuPaZoeEG6ovbc8M79w0QyM'
+
+req_options = {
+  use_ssl: uri.scheme == 'https'
+}
+res = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+  http.request(req)
+end
+
+```

--- a/src/snippets/rust/contacts_api/_get_contact_by_bsuid.mdx
+++ b/src/snippets/rust/contacts_api/_get_contact_by_bsuid.mdx
@@ -1,0 +1,23 @@
+```rust
+extern crate reqwest;
+use reqwest::header;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer test_gshuPaZoeEG6ovbc8M79w0QyM".parse().unwrap());
+    headers.insert("Content-Type", "application/json".parse().unwrap());
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client.get("https://api.callbell.eu/v1/contacts/bsuid/bsuid_abc123")
+        .headers(headers)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+```


### PR DESCRIPTION
Adds documentation for the new BSUID contact lookup endpoint, including code examples for all 9 supported languages (curl, Node.js, Python, Ruby, Go, PHP, Java, C#, Rust).

Companion PR: callbellchat/callbell#5295