### PR TITLE
docs: document contact note field in public API (CAL-1058)

### DIFF
--- a/docs/api/reference/contacts_api/patch_contacts.md
+++ b/docs/api/reference/contacts_api/patch_contacts.md
@@ -26,6 +26,7 @@ Updates an existing contact.
 | `unassign_user` | Boolean  | `true` is you want to remove the assigned collaborator from a contact            |
 | `team_uuid`     | String   | UUID of the team that you want to assign to a contact                            |
 | `bot_status`    | String   | The status of the bot for this contact. Accepts either `bot_start` or `bot_end`. |
+| `note`          | String   | A free-text note associated with the contact (up to 1000 characters). Pass an empty string to clear the note; omit the key to leave it unchanged. |
 
 :::info
 When passing `bot_status` make sure that the bot is enabled in your account. Visit [bots](https://dash.callbell.eu/bots) in your Callbell account to create and enable one.

--- a/docs/api/reference/contacts_api/post_contacts.md
+++ b/docs/api/reference/contacts_api/post_contacts.md
@@ -27,6 +27,7 @@ Creates a new contact.
 | `team_uuid`     | String   | UUID of the team that you want to assign to a contact                                                   |
 | `channel_uuid`  | String   | The message will be sent from this channel (when omitted, it will use the default main channel)         |
 | `bot_status`    | String   | The status of the bot for this contact. The status of the bot. Accepts either `bot_start` or `bot_end`. |
+| `note`          | String   | A free-text note associated with the contact (up to 1000 characters).                                   |
 
 :::info
 When passing `bot_status` make sure that the bot is enabled in your account. Visit [bots](https://dash.callbell.eu/bots) in your Callbell account to create and enable one.

--- a/docs/api/reference/object_types/contact.md
+++ b/docs/api/reference/object_types/contact.md
@@ -25,3 +25,4 @@ sidebar_position: 1
 | `team`                 | [Team](./team.md)       | Team inbox currently associated to the contact                                                      |
 | `channel`              | [Channel](./channel.md) | Channel currently associated to the contact                                                         |
 | `bsuid`                | string                  | WhatsApp Business Suite User ID. Only present for WhatsApp Cloud API contacts with a known BSUID.   |
+| `note`                 | string                  | Free-text note associated with the contact (up to 1000 characters). `null` when no note is set.    |

--- a/docs/api/release_notes.md
+++ b/docs/api/release_notes.md
@@ -6,6 +6,12 @@ sidebar_position: 4
 
 A list of all the changes and enhancements that were introduced in our API. Use it to check whenever new endpoints are added, or changes are made.
 
+## July 1, 2026
+
+### ✨ What's new
+
+- Added `note` field to the [Contact](/api/reference/object_types/contact) object type. It can now be set when [creating](/api/reference/contacts_api/post_contacts) or [updating](/api/reference/contacts_api/patch_contacts) a contact (free-text, up to 1000 characters).
+
 ## March 3, 2026
 
 ### ✨ What's new


### PR DESCRIPTION
## Summary

Documents the new contact `note` field exposed through the public API in [callbell#5350](https://github.com/callbellchat/callbell/pull/5350). The note is a free-text field (up to 1000 characters) available on the existing contact endpoints, with no new routes.

## What changed

- **Contact object type** — added `note` to the response field table (returned by GET /contacts and GET /contacts/:id).
- **POST /contacts** — added `note` as an optional parameter.
- **PATCH /contacts/:uuid** — added `note` as an optional parameter, documenting that an empty string clears the note and omitting the key leaves it unchanged.

Follows the same English-only pattern used for the recent `bsuid` field docs (these files have no i18n copies yet).

[CAL-1058](https://linear.app/callbell/issue/CAL-1058/expose-contact-note-editing-in-public-api)